### PR TITLE
Compatibility validator improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ apiValidation {
      * Sub-projects that are excluded from API validation 
      */
     ignoredProjects += ["benchmarks", "examples"]
+    
+    /**
+     * Set of annotations that exclude API from being public.
+     * Typically, it is all kinds of `@InternalApi` annotations that mark 
+     * effectively private API that cannot be actually private for technical reasons.
+     */
+    nonPublicMarkers += ["my.package.MyInternalApiAnnotation"]
+
+    /**
+     * Flag to programmatically disable compatibility validator
+     */
+    validationDisabled = true
 }
 ```
 

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -22,4 +22,10 @@ open class ApiValidationExtension {
      * Projects that are ignored by the API check.
      */
     public var ignoredProjects: MutableSet<String> = HashSet()
+
+    /**
+     * Fully qualified names of annotations that effectively exclude declarations from being public.
+     * Example of such annotation could be `kotlinx.coroutines.InternalCoroutinesApi`.
+     */
+    public var nonPublicMarkers: MutableSet<String> = HashSet()
 }

--- a/src/main/kotlin/ExternalApi.kt
+++ b/src/main/kotlin/ExternalApi.kt
@@ -6,7 +6,7 @@
 package kotlinx.validation
 
 /**
- * API that is used externally and programmatically by Kotlin standard library
+ * API that is used externally and programmatically by binary-compatibility-validator tool in Kotlin standard library
  */
 @Retention(AnnotationRetention.SOURCE)
 annotation class ExternalApi

--- a/src/main/kotlin/ExternalApi.kt
+++ b/src/main/kotlin/ExternalApi.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation
+
+/**
+ * API that is used externally and programmatically by Kotlin standard library
+ */
+@Retention(AnnotationRetention.SOURCE)
+annotation class ExternalApi

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -40,6 +40,7 @@ open class KotlinApiBuildTask : DefaultTask() {
             .map { it.inputStream() }
             .loadApiFromJvmClasses()
             .filterOutNonPublic(extension.ignoredPackages)
+            .filterOutAnnotated(extension.nonPublicMarkers.map { it.replace(".", "/") }.toSet())
 
         outputApiDir.resolve("${project.name}.api").bufferedWriter().use { writer ->
             signatures

--- a/src/main/kotlin/api/AsmMetadataLoading.kt
+++ b/src/main/kotlin/api/AsmMetadataLoading.kt
@@ -6,7 +6,7 @@
 package kotlinx.validation.api
 
 import kotlinx.metadata.jvm.*
-import org.objectweb.asm.Opcodes
+import org.objectweb.asm.*
 import org.objectweb.asm.tree.*
 
 val ACCESS_NAMES = mapOf(
@@ -70,8 +70,14 @@ private fun List<Any>.annotationValue(key: String): Any? {
     return null
 }
 
-private fun findAnnotation(annotationName: String, visibleAnnotations: List<AnnotationNode>?, invisibleAnnotations: List<AnnotationNode>?, includeInvisible: Boolean): AnnotationNode? =
+private fun findAnnotation(
+    annotationName: String,
+    visibleAnnotations: List<AnnotationNode>?,
+    invisibleAnnotations: List<AnnotationNode>?,
+    includeInvisible: Boolean
+): AnnotationNode? =
     visibleAnnotations?.firstOrNull { it.refersToName(annotationName) }
-            ?: if (includeInvisible) invisibleAnnotations?.firstOrNull { it.refersToName(annotationName) } else null
+        ?: if (includeInvisible) invisibleAnnotations?.firstOrNull { it.refersToName(annotationName) } else null
 
-fun AnnotationNode.refersToName(name: String) = desc.startsWith('L') && desc.endsWith(';') && desc.regionMatches(1, name, 0, name.length)
+fun AnnotationNode.refersToName(name: String) =
+    desc.startsWith('L') && desc.endsWith(';') && desc.regionMatches(1, name, 0, name.length)

--- a/src/main/kotlin/api/KotlinMetadataSignature.kt
+++ b/src/main/kotlin/api/KotlinMetadataSignature.kt
@@ -6,9 +6,11 @@
 package kotlinx.validation.api
 
 import kotlinx.metadata.jvm.*
+import kotlinx.validation.*
 import org.objectweb.asm.tree.FieldNode
 import org.objectweb.asm.tree.MethodNode
 
+@ExternalApi // Only name is part of the API, nothing else is used by stdlib
 data class ClassBinarySignature(
     val name: String,
     val superName: String,


### PR DESCRIPTION
* ExternalApi annotation to mark declarations that stdlib depends on
* New nonPublicMarkers API for filtering out effectively internal API