### PR TITLE
Add ignoredPackages and nonPublicMarkers as @Input parameters

### DIFF
--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -28,6 +28,12 @@ open class KotlinApiBuildTask : DefaultTask() {
     @OutputDirectory
     lateinit var outputApiDir: File
 
+    @get:Input
+    val ignoredPackages : Set<String> get() = extension.ignoredPackages
+
+    @get:Input
+    val nonPublicMarkers : Set<String> get() = extension.nonPublicMarkers
+
     @TaskAction
     fun generate() {
         cleanup(outputApiDir)
@@ -39,8 +45,8 @@ open class KotlinApiBuildTask : DefaultTask() {
             }
             .map { it.inputStream() }
             .loadApiFromJvmClasses()
-            .filterOutNonPublic(extension.ignoredPackages)
-            .filterOutAnnotated(extension.nonPublicMarkers.map { it.replace(".", "/") }.toSet())
+            .filterOutNonPublic(ignoredPackages)
+            .filterOutAnnotated(nonPublicMarkers.map { it.replace(".", "/") }.toSet())
 
         outputApiDir.resolve("${project.name}.api").bufferedWriter().use { writer ->
             signatures


### PR DESCRIPTION
I'm adding `ignoredPackages` and `nonPublicMarkers` as `@Input` parameters for the `apiBuild` task. 

Currently, editing those two parameters are not considered by Gradle when computing if the `apiBuild` task is UP-TO-DATE or not. This means that, as of today, if you add a package inside `ignoredPackages` and invoke `gw apiCheck` afterwards, the task will succeed as UP-TO-DATE as the input/output for the `apiBuild` were unchanged.

This PR fixes this bug, allowing to account for both `ignoredPackages` and `nonPublicMarkers` when computing if the task should be executed.

