### PR TITLE
Support multiplatform when android is only JVM target

### DIFF
--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -59,10 +59,16 @@ class BinaryCompatibilityValidatorPlugin : Plugin<Project> {
             if (project.name in project.rootProject.ignoredProjects()) return@withPlugin
             val kotlin = project.extensions.getByName("kotlin") as KotlinMultiplatformExtension
             kotlin.targets.matching {
-                it.platformType == KotlinPlatformType.jvm
+                it.platformType == KotlinPlatformType.jvm || it.platformType == KotlinPlatformType.androidJvm
             }.all { target ->
-                target.compilations.matching { it.name == "main" }.all {
-                    project.configureKotlinCompilation(it)
+                if (target.platformType == KotlinPlatformType.jvm) {
+                    target.compilations.matching { it.name == "main" }.all {
+                        project.configureKotlinCompilation(it)
+                    }
+                } else if (target.platformType == KotlinPlatformType.androidJvm) {
+                    target.compilations.matching { it.name == "release" }.all {
+                        project.configureKotlinCompilation(it, useOutput = true)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds support for `kotlin("multiplatform")` projects configured with `android()` as the only JVM target, for example:

```kotlin
plugins {
    id("com.android.library")
    kotlin("multiplatform")
}

kotlin {
    android()
    js().browser()

    // ...
}
```

_`jvm` platform type is favored when both `jvm()` and `android()` targets are present._