### PR TITLE
Introduce 'ignoredClasses' configuration to exclude classes by fully …

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ The plugin provides two tasks:
 
 Binary compatibility validator can be additionally configured with the following DSL:
 
-```kotlin
+Groovy
+```groovy
 apiValidation {
     /**
      * Packages that are excluded from public API dumps even if they
@@ -63,7 +64,13 @@ apiValidation {
      * Sub-projects that are excluded from API validation 
      */
     ignoredProjects += ["benchmarks", "examples"]
-    
+
+    /**
+     * Classes (fully qualified) that are excluded from public API dumps even if they
+     * contain public API.
+     */
+    ignoredClasses += ["com.company.BuildConfig"]
+
     /**
      * Set of annotations that exclude API from being public.
      * Typically, it is all kinds of `@InternalApi` annotations that mark 
@@ -78,6 +85,39 @@ apiValidation {
 }
 ```
 
+Kotlin
+```kotlin
+configure<kotlinx.validation.ApiValidationExtension> {
+    /**
+     * Packages that are excluded from public API dumps even if they
+     * contain public API.
+     */
+    ignoredPackages.add("kotlinx.coroutines.internal")
+
+    /**
+     * Sub-projects that are excluded from API validation
+     */
+    ignoredProjects.addAll(listOf("benchmarks", "examples"))
+
+    /**
+     * Classes (fully qualified) that are excluded from public API dumps even if they
+     * contain public API.
+     */
+    ignoredClasses.add("com.company.BuildConfig")
+    
+    /**
+     * Set of annotations that exclude API from being public.
+     * Typically, it is all kinds of `@InternalApi` annotations that mark
+     * effectively private API that cannot be actually private for technical reasons.
+     */
+    nonPublicMarkers.add("my.package.MyInternalApiAnnotation")
+
+    /**
+     * Flag to programmatically disable compatibility validator
+     */
+    validationDisabled = false
+}
+```
 
 ### Workflow
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,24 @@ sourceSets {
     }
 }
 
+sourceSets {
+    create("functionalTest") {
+        withConvention(org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet::class) {
+        }
+        resources {
+            srcDir(file("src/functionalTest/resources"))
+        }
+        compileClasspath += sourceSets.main.get().output + configurations.testRuntimeClasspath
+        runtimeClasspath += output + compileClasspath
+    }
+}
+
+tasks.register<Test>("functionalTest") {
+    testClassesDirs = sourceSets["functionalTest"].output.classesDirs
+    classpath = sourceSets["functionalTest"].runtimeClasspath
+}
+tasks.check { dependsOn(tasks["functionalTest"]) }
+
 dependencies {
     implementation(gradleApi())
     implementation(kotlin("stdlib-jdk8"))
@@ -31,6 +49,10 @@ dependencies {
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
     compileOnly("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.3.61")
     testImplementation(kotlin("test-junit"))
+
+    "functionalTestImplementation"("org.assertj:assertj-core:3.18.1")
+    "functionalTestImplementation"(gradleTestKit())
+    "functionalTestImplementation"(kotlin("test-junit"))
 }
 
 tasks.withType<KotlinCompile>().configureEach {
@@ -77,6 +99,8 @@ extensions.getByType(PluginBundleExtension::class).apply {
 }
 
 gradlePlugin {
+    testSourceSets(sourceSets["functionalTest"])
+
     plugins {
         create("binary-compatibility-validator") {
             id = "org.jetbrains.kotlinx.binary-compatibility-validator"

--- a/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.api
+
+import org.junit.Before
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+internal open class BaseKotlinGradleTest {
+    @Rule
+    @JvmField
+    internal val testProjectDir: TemporaryFolder = TemporaryFolder()
+    internal lateinit var apiDump: File
+
+    @Before
+    fun setup() {
+        apiDump = testProjectDir.newFolder("api")
+                .toPath()
+                .resolve("${testProjectDir.root.name}.api")
+                .toFile()
+                .apply {
+                    createNewFile()
+                }
+    }
+}

--- a/src/functionalTest/kotlin/kotlinx/validation/api/assert.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/assert.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.api
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+import kotlin.test.assertEquals
+
+/**
+ * Helper `fun` for asserting a [TaskOutcome] to be equal to [TaskOutcome.SUCCESS]
+ */
+internal fun BuildResult.assertTaskSuccess(task: String) {
+    assertTaskOutcome(TaskOutcome.SUCCESS, task)
+}
+
+/**
+ * Helper `fun` for asserting a [TaskOutcome] to be equal to [TaskOutcome.FAILED]
+ */
+internal fun BuildResult.assertTaskFailure(task: String) {
+    assertTaskOutcome(TaskOutcome.FAILED, task)
+}
+
+private fun BuildResult.assertTaskOutcome(taskOutcome: TaskOutcome, taskName: String) {
+    assertEquals(taskOutcome, task(taskName)?.outcome)
+}

--- a/src/functionalTest/kotlin/kotlinx/validation/api/resourceExt.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/resourceExt.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.api
+
+import java.io.File
+
+internal fun readFileList(fileName: String): String {
+    val resource = BaseKotlinGradleTest::class.java.classLoader.getResource(fileName)
+            ?: throw IllegalStateException("Could not find resource '$fileName'")
+    return File(resource.toURI()).readText()
+}

--- a/src/functionalTest/kotlin/kotlinx/validation/api/testDsl.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/testDsl.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.api
+
+import org.gradle.testkit.runner.GradleRunner
+
+internal fun BaseKotlinGradleTest.test(fn: BaseKotlinScope.() -> Unit): GradleRunner {
+    val baseKotlinScope = BaseKotlinScope()
+    fn(baseKotlinScope)
+
+    baseKotlinScope.files.forEach { scope ->
+        val fileWriteTo = testProjectDir.root.resolve(scope.filePath)
+                .apply {
+                    parentFile.mkdirs()
+                    createNewFile()
+                }
+
+        scope.files.forEach {
+            val fileContent = readFileList(it)
+            fileWriteTo.appendText("\n" + fileContent)
+        }
+    }
+
+    return GradleRunner.create() //
+            .withProjectDir(testProjectDir.root)
+            .withPluginClasspath()
+            .withArguments(baseKotlinScope.runner.arguments)
+    // disabled because of: https://github.com/gradle/gradle/issues/6862
+    // .withDebug(baseKotlinScope.runner.debug)
+}
+
+internal fun BaseKotlinScope.file(fileName: String, fn: AppendableScope.() -> Unit) {
+    val appendableScope = AppendableScope(fileName)
+    fn(appendableScope)
+
+    files.add(appendableScope)
+}
+
+/**
+ * same as [file], but appends "src/main/java" before given `classFileName`
+ */
+internal fun BaseKotlinScope.kotlin(classFileName: String, fn: AppendableScope.() -> Unit) {
+    require(classFileName.endsWith(".kt")) {
+        "ClassFileName must end with '.kt'"
+    }
+
+    val fileName = "src/main/java/$classFileName"
+    file(fileName, fn)
+}
+
+/**
+ * Shortcut for creating a `build.gradle.kts` by using [file]
+ */
+internal fun BaseKotlinScope.buildGradleKts(fn: AppendableScope.() -> Unit) {
+    val fileName = "build.gradle.kts"
+    file(fileName, fn)
+}
+
+internal fun BaseKotlinScope.runner(fn: Runner.() -> Unit) {
+    val runner = Runner()
+    fn(runner)
+
+    this.runner = runner
+}
+
+internal fun AppendableScope.resolve(fileName: String) {
+    this.files.add(fileName)
+}
+
+internal class BaseKotlinScope {
+    var files: MutableList<AppendableScope> = mutableListOf()
+    var runner: Runner = Runner()
+}
+
+internal class AppendableScope(val filePath: String) {
+    val files: MutableList<String> = mutableListOf()
+}
+
+internal class Runner {
+    var debug = false
+    val arguments: MutableList<String> = mutableListOf()
+}

--- a/src/functionalTest/kotlin/kotlinx/validation/test/GradlePluginFuncTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/GradlePluginFuncTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.test
+
+import kotlinx.validation.api.BaseKotlinGradleTest
+import kotlinx.validation.api.assertTaskFailure
+import kotlinx.validation.api.assertTaskSuccess
+import kotlinx.validation.api.buildGradleKts
+import kotlinx.validation.api.kotlin
+import kotlinx.validation.api.runner
+import kotlinx.validation.api.readFileList
+import kotlinx.validation.api.resolve
+import kotlinx.validation.api.test
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+internal class GradlePluginFuncTest : BaseKotlinGradleTest() {
+    @Test
+    fun `apiCheck should succeed, when no kotlin files are included in SourceSet`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/default/build.gradle.kts")
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+
+    @Test
+    fun `apiCheck should succeed, when given class is not in api-File, but is ignored via ignoredClasses`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/default/build.gradle.kts")
+                resolve("examples/gradle/configuration/ignoredClasses/oneValidFullyQualifiedClass.gradle.kts")
+            }
+
+            kotlin("BuildConfig.kt") {
+                resolve("examples/classes/BuildConfig.kt")
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+
+    @Test
+    fun `apiCheck should fail, when a public class is not in api-File`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/default/build.gradle.kts")
+            }
+
+            kotlin("BuildConfig.kt") {
+                resolve("examples/classes/BuildConfig.kt")
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.buildAndFail().apply {
+            val dumpOutput =
+                    "  @@ -1,1 +1,7 @@\n" +
+                            "  +public final class com/company/BuildConfig {\n" +
+                            "  +\tpublic fun <init> ()V\n" +
+                            "  +\tpublic final fun function ()I\n" +
+                            "  +\tpublic final fun getProperty ()I\n" +
+                            "  +}"
+
+            assertTaskFailure(":apiCheck")
+            Assertions.assertThat(output).contains(dumpOutput)
+        }
+    }
+
+    @Test
+    fun `apiCheck should succeed, when given class is not in api-File, but is ignored via ignoredPackages`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/default/build.gradle.kts")
+                resolve("examples/gradle/configuration/ignoredPackages/oneValidPackage.gradle.kts")
+            }
+
+            kotlin("BuildConfig.kt") {
+                resolve("examples/classes/BuildConfig.kt")
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+
+    @Test
+    fun `apiDump should not dump ignoredClasses, when class is excluded via ignoredClasses`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/default/build.gradle.kts")
+                resolve("examples/gradle/configuration/ignoredClasses/oneValidFullyQualifiedClass.gradle.kts")
+            }
+            kotlin("BuildConfig.kt") {
+                resolve("examples/classes/BuildConfig.kt")
+            }
+            kotlin("AnotherBuildConfig.kt") {
+                resolve("examples/classes/AnotherBuildConfig.kt")
+            }
+
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            val expected = readFileList("examples/classes/AnotherBuildConfig.dump")
+            Assertions.assertThat(apiDump.readText()).isEqualToIgnoringNewLines(expected)
+        }
+    }
+}

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfig.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfig.dump
@@ -1,0 +1,5 @@
+public final class org/different/pack/BuildConfig {
+	public fun <init> ()V
+	public final fun f1 ()I
+	public final fun getP1 ()I
+}

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfig.kt
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfig.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package org.different.pack
+
+public class BuildConfig {
+    public val p1 = 1
+
+    public fun f1() = p1
+}

--- a/src/functionalTest/resources/examples/classes/BuildConfig.kt
+++ b/src/functionalTest/resources/examples/classes/BuildConfig.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package com.company
+
+public class BuildConfig {
+    public val property = 1
+
+    public fun function() = property
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/ignoredClasses/oneValidFullyQualifiedClass.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/ignoredClasses/oneValidFullyQualifiedClass.gradle.kts
@@ -1,0 +1,3 @@
+configure<kotlinx.validation.ApiValidationExtension> {
+    ignoredClasses.add("com.company.BuildConfig")
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/ignoredPackages/oneValidPackage.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/ignoredPackages/oneValidPackage.gradle.kts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    ignoredPackages.add("com.company")
+}

--- a/src/functionalTest/resources/examples/gradle/default/build.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/default/build.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+plugins {
+    kotlin("jvm") version "1.3.70"
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8"))
+}

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -28,4 +28,10 @@ open class ApiValidationExtension {
      * Example of such annotation could be `kotlinx.coroutines.InternalCoroutinesApi`.
      */
     public var nonPublicMarkers: MutableSet<String> = HashSet()
+
+    /**
+     * Fully qualified names of classes that are ignored by the API check.
+     * Example of such a class could be `com.package.android.BuildConfig`.
+     */
+    public var ignoredClasses: MutableSet<String> = HashSet()
 }

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -34,6 +34,9 @@ open class KotlinApiBuildTask : DefaultTask() {
     @get:Input
     val nonPublicMarkers : Set<String> get() = extension.nonPublicMarkers
 
+    @get:Input
+    val ignoredClasses : Set<String> get() = extension.ignoredClasses
+
     @TaskAction
     fun generate() {
         cleanup(outputApiDir)
@@ -45,7 +48,7 @@ open class KotlinApiBuildTask : DefaultTask() {
             }
             .map { it.inputStream() }
             .loadApiFromJvmClasses()
-            .filterOutNonPublic(ignoredPackages)
+            .filterOutNonPublic(ignoredPackages, ignoredClasses)
             .filterOutAnnotated(nonPublicMarkers.map { it.replace(".", "/") }.toSet())
 
         outputApiDir.resolve("${project.name}.api").bufferedWriter().use { writer ->

--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -73,12 +73,19 @@ internal fun List<ClassBinarySignature>.filterOutAnnotated(targetAnnotations: Se
 }
 
 @ExternalApi
-public fun List<ClassBinarySignature>.filterOutNonPublic(nonPublicPackages: Collection<String> = emptyList()): List<ClassBinarySignature> {
-    val nonPublicPaths = nonPublicPackages.map { it.replace('.', '/') + '/' }
+public fun List<ClassBinarySignature>.filterOutNonPublic(nonPublicPackages: Collection<String> = emptyList(), nonPublicClasses: Collection<String> = emptyList()): List<ClassBinarySignature> {
+    val pathMapper: (String) -> String = { it.replace('.', '/') + '/' }
+    val nonPublicPackagePaths = nonPublicPackages.map(pathMapper)
+    val excludedClasses = nonPublicClasses.map(pathMapper)
+
     val classByName = associateBy { it.name }
 
     fun ClassBinarySignature.isInNonPublicPackage() =
-        nonPublicPaths.any { name.startsWith(it) }
+        nonPublicPackagePaths.any { name.startsWith(it) }
+
+    // checks whether class (e.g. com/company/BuildConfig) is in excluded class (e.g. com/company/BuildConfig/)
+    fun ClassBinarySignature.isInExcludedClasses() =
+        excludedClasses.any { it.startsWith(name) }
 
     fun ClassBinarySignature.isPublicAndAccessible(): Boolean =
         isEffectivelyPublic &&
@@ -105,7 +112,7 @@ public fun List<ClassBinarySignature>.filterOutNonPublic(nonPublicPackages: Coll
         )
     }
 
-    return filter { !it.isInNonPublicPackage() && it.isPublicAndAccessible() }
+    return filter { !it.isInNonPublicPackage() && !it.isInExcludedClasses() && it.isPublicAndAccessible() }
         .map { it.flattenNonPublicBases() }
         .filterNot { it.isNotUsedWhenEmpty && it.memberSignatures.isEmpty() }
 }


### PR DESCRIPTION
Fixes #25

Open Points: 
* which code formatter should I use?
_should I move the functional-Tests to a different source-set?_

I touched a public API, which is used in Kotlin-STD-Lib. I think the change is breaking (byte-code), but when updating to another version, the calling could must only re-compile against the newest version. It should re-compile without issues, because a default value is provided.

```
@ExternalApi
public fun List<ClassBinarySignature>.filterOutNonPublic(nonPublicPackages: Collection<String> = emptyList(), nonPublicClasses: Collection<String> = emptyList()): List<ClassBinarySignature> {
``` 

Edit:
I moved the Gradle-Plugin functionalTests to their own SourceSet. Test will be run, when `gw test` is executed.