### PR TITLE
Use defaultPublishConfig if possible for android modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ apiValidation {
      * Flag to programmatically disable compatibility validator
      */
     validationDisabled = true
+
+    /**
+     * Manually set compilation name which should be checked.
+     * Typically this can be used for multi-flavor builds with multiple targets, where you want check different
+     * one that common default.
+     */
+    checkedCompilation = "releaseInternal"
 }
 ```
 
@@ -116,6 +123,13 @@ configure<kotlinx.validation.ApiValidationExtension> {
      * Flag to programmatically disable compatibility validator
      */
     validationDisabled = false
+
+    /**
+     * Manually set compilation name which should be checked.
+     * Typically this can be used for multi-flavor builds with multiple targets, where you want check different
+     * one that common default.
+     */
+    checkedCompilation = "releaseInternal"
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
     mavenCentral()
     jcenter()
     gradlePluginPortal()
+    google()
 }
 
 sourceSets {
@@ -49,6 +50,7 @@ dependencies {
     implementation("org.ow2.asm:asm-tree:6.0")
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
     compileOnly("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.3.61")
+    compileOnly("com.android.tools.build:gradle:4.1.1")
     testImplementation(kotlin("test-junit"))
 
     "functionalTestImplementation"("org.assertj:assertj-core:3.18.1")

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -34,4 +34,13 @@ open class ApiValidationExtension {
      * Example of such a class could be `com.package.android.BuildConfig`.
      */
     public var ignoredClasses: MutableSet<String> = HashSet()
+
+    /**
+     * Name of kotlin compilation target which should be checked.
+     * Example of such target for android could be `releaseBackendProductionVanilla`.
+     *
+     * If left empty default target compilation will be used.
+     */
+    public var checkedCompilation: String? = null
+
 }

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -49,9 +49,9 @@ class BinaryCompatibilityValidatorPlugin : Plugin<Project> {
         project.pluginManager.withPlugin("kotlin-android") {
             if (project.name in project.rootProject.ignoredProjects()) return@withPlugin
             val extension = project.extensions.getByName("kotlin") as KotlinAndroidProjectExtension
-            val targetedPublications = project.targetedCompilation(extension.target.platformType)
+            val compilation = project.targetedCompilation(extension.target.platformType)
             extension.target.compilations.matching {
-                it.compilationName == targetedPublications
+                it.compilationName == compilation
             }.all {
                 project.configureKotlinCompilation(it, useOutput = true)
             }
@@ -64,9 +64,9 @@ class BinaryCompatibilityValidatorPlugin : Plugin<Project> {
                 it.platformType == KotlinPlatformType.jvm || it.platformType == KotlinPlatformType.androidJvm
             }.all { target ->
                 val useOutput = target.platformType == KotlinPlatformType.androidJvm
-                val targetedCompilation = project.targetedCompilation(target.platformType)
+                val compilation = project.targetedCompilation(target.platformType)
                 target.compilations.matching {
-                    it.name == targetedCompilation
+                    it.name == compilation
                 }.all {
                     project.configureKotlinCompilation(it, useOutput = useOutput)
                 }


### PR DESCRIPTION
Fixes #24 

I have prepared fix for #24 by adding compileOnly dependency on android gradle plugin (`com.android.tools.build:gradle:3.6.4`) and using android project extension to fetch [defaultPublishConfig](https://google.github.io/android-gradle-dsl/3.4/com.android.build.gradle.BaseExtension.html#com.android.build.gradle.BaseExtension:defaultPublishConfig) as preferred source of `compilationName` match.