### PR TITLE
Update kotlin to 1.4.30, kotlinx-metadata-jvm to 0.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,9 +42,7 @@ tasks.check { dependsOn(tasks["functionalTest"]) }
 
 dependencies {
     implementation(gradleApi())
-    implementation(kotlin("stdlib-jdk8"))
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.2.0")
     implementation("org.ow2.asm:asm:9.0")
     implementation("org.ow2.asm:asm-tree:9.0")
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
@@ -61,6 +59,9 @@ tasks.withType<KotlinCompile>().configureEach {
         languageVersion = "1.3"
         jvmTarget = "1.8"
         allWarningsAsErrors = true
+        // Suppress the warning about kotlin-reflect 1.3 and kotlin-stdlib 1.4 in the classpath.
+        // It's incorrect in this case because we're limiting API version to 1.3 anyway.
+        freeCompilerArgs += "-Xskip-runtime-version-check"
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,6 +4,7 @@
  */
 
 import org.jetbrains.kotlin.gradle.plugin.*
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.*
 
 plugins {
@@ -28,4 +29,12 @@ sourceSets["main"].withConvention(KotlinSourceSet::class) { kotlin.srcDirs("src"
 
 kotlinDslPluginOptions {
     experimentalWarning.set(false)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.apply {
+        allWarningsAsErrors = true
+        apiVersion = "1.3"
+        freeCompilerArgs += "-Xskip-runtime-version-check"
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=0.4.0-SNAPSHOT
 group=org.jetbrains.kotlinx
 
-kotlinVersion=1.3.70
+kotlinVersion=1.4.30
 pluginPublishVersion=0.10.1


### PR DESCRIPTION
kotlinx-metadata-jvm 0.1.0 cannot read metadata of version 1.5 and
greater. JVM metadata version will be advanced to 1.5 in Kotlin 1.5.