### PR TITLE
Use Kotlin 1.4 in API dump tests 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,11 @@ java {
 }
 
 tasks {
+    compileTestKotlin {
+        kotlinOptions {
+            languageVersion = "1.4"
+        }
+    }
     test {
         systemProperty("overwrite.output", System.getProperty("overwrite.output", "false"))
         systemProperty("testCasesClassesDirs", sourceSets.test.get().output.classesDirs.asPath)

--- a/src/test/kotlin/cases/companions/companions.txt
+++ b/src/test/kotlin/cases/companions/companions.txt
@@ -19,7 +19,7 @@ public final class cases/companions/PublicClasses {
 }
 
 public abstract class cases/companions/PublicClasses$AbstractProtectedCompanion {
-	public static final field Companion Lcases/companions/PublicClasses$AbstractProtectedCompanion$Companion;
+	protected static final field Companion Lcases/companions/PublicClasses$AbstractProtectedCompanion$Companion;
 	public fun <init> ()V
 }
 
@@ -32,12 +32,10 @@ public final class cases/companions/PublicClasses$InternalCompanion {
 }
 
 public final class cases/companions/PublicClasses$PrivateCompanion {
-	public static final field Companion Lcases/companions/PublicClasses$PrivateCompanion$Companion;
 	public fun <init> ()V
 }
 
 public final class cases/companions/PublicClasses$ProtectedCompanion {
-	public static final field Companion Lcases/companions/PublicClasses$ProtectedCompanion$Companion;
 	public fun <init> ()V
 }
 
@@ -54,7 +52,7 @@ public final class cases/companions/PublicInterfaces {
 }
 
 public abstract interface class cases/companions/PublicInterfaces$PrivateCompanion {
-	public static final field Companion Lcases/companions/PublicInterfaces$PrivateCompanion$Companion;
+	public static final synthetic field Companion Lcases/companions/PublicInterfaces$PrivateCompanion$Companion;
 }
 
 public abstract interface class cases/companions/PublicInterfaces$PublicCompanion {


### PR DESCRIPTION
... and update public API dump after [KT-11567](https://youtrack.jetbrains.com/issue/KT-11567) codegen changes came into effect

The only questionable case left is a private companion in a public interface, which is generated as a public synthetic field.