### PR TITLE
Support Gradle's configuration cache

### DIFF
--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -97,6 +97,7 @@ private fun Project.configureKotlinCompilation(
             inputDependencies = files(provider<Any> { if (isEnabled) compilation.compileDependencyFiles else emptyList<Any>() })
         }
         outputApiDir = apiBuildDir
+        this.projectName.set(project.name)
     }
     configureCheckTasks(apiBuildDir, apiBuild, extension)
 }
@@ -118,6 +119,7 @@ private fun Project.configureApiTasks(sourceSet: SourceSet, extension: ApiValida
         inputClassesDirs = files(provider<Any> { if (isEnabled) sourceSet.output.classesDirs else emptyList<Any>() })
         inputDependencies = files(provider<Any> { if (isEnabled) sourceSet.output.classesDirs else emptyList<Any>() })
         outputApiDir = apiBuildDir
+        this.projectName.set(project.name)
     }
 
     configureCheckTasks(apiBuildDir, apiBuild, extension)
@@ -141,6 +143,7 @@ private fun Project.configureCheckTasks(
             null
         }
         this.apiBuildDir = apiBuildDir
+        this.projectName.set(project.name)
         dependsOn(apiBuild)
     }
 

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -36,6 +36,9 @@ open class KotlinApiBuildTask @Inject constructor(
     @get:Input
     val ignoredClasses : Set<String> get() = extension.ignoredClasses
 
+    @get:Input
+    val projectName = project.objects.property(String::class.java)
+
     @TaskAction
     fun generate() {
         cleanup(outputApiDir)
@@ -50,7 +53,7 @@ open class KotlinApiBuildTask @Inject constructor(
             .filterOutNonPublic(ignoredPackages, ignoredClasses)
             .filterOutAnnotated(nonPublicMarkers.map { it.replace(".", "/") }.toSet())
 
-        outputApiDir.resolve("${project.name}.api").bufferedWriter().use { writer ->
+        outputApiDir.resolve("${projectName.get()}.api").bufferedWriter().use { writer ->
             signatures
                 .sortedBy { it.name }
                 .forEach { api ->


### PR DESCRIPTION
I had a little trouble testing to see if I was successful, but this should allow builds using the Gradle plugin to take advantage of Gradle's [configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) by removing direct access to `project` during task execution.