### PR TITLE
Add nullability support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ apiValidation {
      * Flag to programmatically disable compatibility validator
      */
     validationDisabled = true
+
+    /**
+     * Enable nullability annotations.
+     * Effectively appending `?` to nullable Types. Disabled by default.
+     */
+    annotateNullability = true
 }
 ```
 
@@ -119,6 +125,12 @@ apiValidation {
      * Flag to programmatically disable compatibility validator
      */
     validationDisabled = false
+
+    /**
+     * Enable nullability annotations.
+     * Effectively appending `?` to nullable Types. Disabled by default.
+     */
+    annotateNullability = true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ For a class member a binary incompatible change is:
  - changing its name
  - changing its descriptor (erased return type and parameter types for methods);
    this includes changing field to method and vice versa
+ - changing the nullability/optionality of a type 
  - changing one of the following access flags:
     - `ACC_PUBLIC`, `ACC_PROTECTED`, `ACC_PRIVATE` — lessening the member visibility
     - `ACC_FINAL` — making non-final field or method final

--- a/src/functionalTest/kotlin/kotlinx/validation/test/AnnotateNullabilityTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/AnnotateNullabilityTests.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.test
+
+import kotlinx.validation.api.*
+import kotlinx.validation.api.BaseKotlinGradleTest
+import kotlinx.validation.api.buildGradleKts
+import kotlinx.validation.api.resolve
+import kotlinx.validation.api.test
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import kotlin.test.assertTrue
+
+internal class AnnotateNullabilityTests : BaseKotlinGradleTest() {
+    @Test
+    fun `apiDump should NOT annotate nullable types by default`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+            }
+
+            kotlin("NullableClass.kt") {
+                resolve("examples/classes/NullableClass.kt")
+            }
+
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            assertTrue(rootProjectApiDump.exists(), "api dump file should exist")
+
+            val expected = readFileList("examples/classes/NullableClass.dump")
+            Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
+        }
+    }
+    @Test
+    fun `apiDump should annotate nullable types, if annotateNullability is enabled`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/annotateNullability/annotateNullabilityEnabled.gradle.kts")
+            }
+
+            kotlin("NullableClass.kt") {
+                resolve("examples/classes/NullableClass.kt")
+            }
+
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            assertTrue(rootProjectApiDump.exists(), "api dump file should exist")
+
+            val expected = readFileList("examples/classes/NullableClassAnnotated.dump")
+            Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
+        }
+    }
+}

--- a/src/functionalTest/resources/examples/classes/NullableClass.dump
+++ b/src/functionalTest/resources/examples/classes/NullableClass.dump
@@ -1,0 +1,6 @@
+public final class com/company/nullable/NullableClass {
+	public fun <init> ()V
+	public final fun f (Ljava/lang/String;)Ljava/lang/Integer;
+	public final fun getP ()Ljava/lang/Integer;
+}
+

--- a/src/functionalTest/resources/examples/classes/NullableClass.kt
+++ b/src/functionalTest/resources/examples/classes/NullableClass.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package com.company.nullable
+
+public class NullableClass {
+    public val p: Int? = null
+
+    public fun f(s: String?): Int? {
+        return null
+    }
+}

--- a/src/functionalTest/resources/examples/classes/NullableClassAnnotated.dump
+++ b/src/functionalTest/resources/examples/classes/NullableClassAnnotated.dump
@@ -1,0 +1,6 @@
+public final class com/company/nullable/NullableClass {
+	public fun <init> ()V
+	public final fun f (Ljava/lang/String?;)Ljava/lang/Integer?;
+	public final fun getP ()Ljava/lang/Integer?;
+}
+

--- a/src/functionalTest/resources/examples/gradle/configuration/annotateNullability/annotateNullabilityEnabled.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/annotateNullability/annotateNullabilityEnabled.gradle.kts
@@ -1,0 +1,3 @@
+configure<kotlinx.validation.ApiValidationExtension> {
+    annotateNullability = true
+}

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -13,6 +13,13 @@ open class ApiValidationExtension {
     public var validationDisabled = false
 
     /**
+     * Enable nullability annotations.
+     *
+     * Effectively appending `?` to nullable Types.
+     */
+    public var annotateNullability = false
+
+    /**
      * Fully qualified package names that are not consider public API.
      * For example, it could be `kotlinx.coroutines.internal` or `kotlinx.serialization.implementation`.
      */

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -36,6 +36,9 @@ open class KotlinApiBuildTask @Inject constructor(
     @get:Input
     val ignoredClasses : Set<String> get() = extension.ignoredClasses
 
+    @get:Input
+    val annotateNullability : Boolean get() = extension.annotateNullability
+
     @TaskAction
     fun generate() {
         cleanup(outputApiDir)
@@ -57,7 +60,7 @@ open class KotlinApiBuildTask @Inject constructor(
                     writer.append(api.signature).appendln(" {")
                     api.memberSignatures
                         .sortedWith(MEMBER_SORT_ORDER)
-                        .forEach { writer.append("\t").appendln(it.signature) }
+                        .forEach { writer.append("\t").appendln(it.signature(annotateNullability)) }
                     writer.appendln("}\n")
                 }
         }

--- a/src/main/kotlin/api/KotlinMetadataSignature.kt
+++ b/src/main/kotlin/api/KotlinMetadataSignature.kt
@@ -42,7 +42,7 @@ interface MemberBinarySignature {
         return classVisibility?.findMember(jvmMember)
     }
 
-    val signature: String
+    fun signature(annotateNullability: Boolean = false): String
 }
 
 data class MethodBinarySignature(
@@ -76,8 +76,8 @@ data class MethodBinarySignature(
             return "(${arguments.joinToString("")})${annotatedDescriptor(type.returnType, annotations)}"
         }
 
-    override val signature: String
-        get() = "${access.getModifierString()} fun $name $annotatedDesc"
+    override fun signature(annotateNullability: Boolean): String =
+            "${access.getModifierString()} fun $name ${if (annotateNullability) annotatedDesc else desc}"
 
     override fun isEffectivelyPublic(classAccess: AccessFlags, classVisibility: ClassVisibility?) =
         super.isEffectivelyPublic(classAccess, classVisibility)
@@ -147,8 +147,8 @@ data class FieldBinarySignature(
     override val access: AccessFlags,
     override val annotations: List<AnnotationNode>
 ) : MemberBinarySignature {
-    override val signature: String
-        get() = "${access.getModifierString()} field $name $desc"
+    override fun signature(annotateNullability: Boolean): String =
+            "${access.getModifierString()} field $name $desc"
 
     override fun findMemberVisibility(classVisibility: ClassVisibility?): MemberVisibility? {
         return super.findMemberVisibility(classVisibility)

--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -129,16 +129,16 @@ public fun List<ClassBinarySignature>.filterOutNonPublic(nonPublicPackages: Coll
 }
 
 @ExternalApi
-public fun List<ClassBinarySignature>.dump() = dump(to = System.out)
+public fun List<ClassBinarySignature>.dump() = dump(to = System.out, annotateNullability = false)
 
 @ExternalApi
-public fun <T : Appendable> List<ClassBinarySignature>.dump(to: T): T {
+public fun <T : Appendable> List<ClassBinarySignature>.dump(to: T, annotateNullability: Boolean): T {
     forEach { classApi ->
         with(to) {
             append(classApi.signature).appendln(" {")
             classApi.memberSignatures
                     .sortedWith(MEMBER_SORT_ORDER)
-                    .forEach { append("\t").appendln(it.signature) }
+                    .forEach { append("\t").appendln(it.signature(annotateNullability)) }
             appendln("}\n")
         }
     }

--- a/src/test/kotlin/cases/default/functions.kt
+++ b/src/test/kotlin/cases/default/functions.kt
@@ -1,24 +1,24 @@
 @file:Suppress("UNUSED_PARAMETER")
 package cases.default
 
-internal fun allDefaults(par1: Any = 1, par2: String? = null) {}
+internal fun allDefaults(par1: Any = 1, par2: String = "") {}
 
-internal fun someDefaults(par1: Any, par2: String? = null) {}
+internal fun someDefaults(par1: Any, par2: String = "") {}
 
 
 open class ClassFunctions {
 
-    internal open fun allDefaults(par1: Any = 1, par2: String? = null) {}
+    internal open fun allDefaults(par1: Any = 1, par2: String = "") {}
 
-    internal open fun someDefaults(par1: Any, par2: String? = null) {}
+    internal open fun someDefaults(par1: Any, par2: String = "") {}
 
 }
 
 
 interface InterfaceFunctions {
 
-    fun withAllDefaults(par1: Int = 1, par2: String? = null)
+    fun withAllDefaults(par1: Int = 1, par2: String = "")
 
-    fun withSomeDefaults(par1: Int, par2: String? = null)
+    fun withSomeDefaults(par1: Int, par2: String = "")
 
 }

--- a/src/test/kotlin/cases/default/publishedApiWithDefaults.kt
+++ b/src/test/kotlin/cases/default/publishedApiWithDefaults.kt
@@ -3,7 +3,9 @@
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 @file:Suppress("UNUSED_PARAMETER")
+
 package cases.default
 
 @PublishedApi
-internal fun twoDefaults(par0: Int, par1: Any = 1, par2: String? = null) {}
+internal fun twoDefaults(par0: Int, par1: Any = 1, par2: String = "") {
+}

--- a/src/test/kotlin/cases/nullable/nullable.txt
+++ b/src/test/kotlin/cases/nullable/nullable.txt
@@ -1,0 +1,37 @@
+public abstract interface class cases/nullable/Nullable {
+	public abstract fun getBasicType ()Ljava/lang/Integer?;
+	public abstract fun getObjectType ()Ljava/lang/String?;
+	public abstract fun operation (Ljava/lang/Integer?;)Ljava/lang/String?;
+	public abstract fun setBasicType (Ljava/lang/Integer?;)V
+	public abstract fun setObjectType (Ljava/lang/String?;)V
+}
+
+public final class cases/nullable/NullableLambda {
+	public fun <init> ()V
+	public final fun allOptional (Lkotlin/jvm/functions/Function1?;)V
+	public final fun intToInt (Lkotlin/jvm/functions/Function1;)V
+	public final fun intToUnit (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class cases/nullable/NullableParameters {
+	public fun <init> ()V
+	public final fun objectType (Ljava/lang/String;Ljava/lang/String?;)V
+	public final fun optionalFirst (Ljava/lang/Integer?;I)V
+	public final fun optionalFirstAndLast (Ljava/lang/Integer?;ILjava/lang/Integer?;)V
+	public final fun optionalSecond (ILjava/lang/Integer?;)V
+}
+
+public final class cases/nullable/NullableProperties {
+	public fun <init> ()V
+	public final fun getBasicType ()Ljava/lang/Integer?;
+	public final fun getObjectType ()Ljava/lang/String?;
+	public final fun setBasicType (Ljava/lang/Integer?;)V
+	public final fun setObjectType (Ljava/lang/String?;)V
+}
+
+public final class cases/nullable/NullableReturnType {
+	public fun <init> ()V
+	public final fun returnBasicType ()Ljava/lang/Integer?;
+	public final fun returnObjectType ()Ljava/lang/String?;
+}
+

--- a/src/test/kotlin/cases/nullable/nullableInInterface.kt
+++ b/src/test/kotlin/cases/nullable/nullableInInterface.kt
@@ -1,0 +1,8 @@
+package cases.nullable
+
+interface Nullable {
+    var objectType: String?
+    var basicType: Int?
+
+    fun operation(i: Int?): String?
+}

--- a/src/test/kotlin/cases/nullable/nullableLambda.kt
+++ b/src/test/kotlin/cases/nullable/nullableLambda.kt
@@ -1,0 +1,9 @@
+@file:Suppress("UNUSED_PARAMETER")
+
+package cases.nullable
+
+class NullableLambda {
+    fun intToUnit(callback: (Int?) -> Unit) {}
+    fun intToInt(callback: (Int?) -> Int) {}
+    fun allOptional(lambda: ((Int?) -> String?)?) {}
+}

--- a/src/test/kotlin/cases/nullable/nullableParameters.kt
+++ b/src/test/kotlin/cases/nullable/nullableParameters.kt
@@ -1,0 +1,10 @@
+@file:Suppress("UNUSED_PARAMETER")
+
+package cases.nullable
+
+class NullableParameters {
+    fun objectType(sure: String, maybe: String?) {}
+    fun optionalFirst(i: Int?, j: Int) {}
+    fun optionalSecond(i: Int, j: Int?) {}
+    fun optionalFirstAndLast(i: Int?, j: Int, k: Int?) {}
+}

--- a/src/test/kotlin/cases/nullable/nullableProperties.kt
+++ b/src/test/kotlin/cases/nullable/nullableProperties.kt
@@ -1,0 +1,6 @@
+package cases.nullable
+
+class NullableProperties {
+    var basicType: Int? = null
+    var objectType: String? = null
+}

--- a/src/test/kotlin/cases/nullable/nullableReturnType.kt
+++ b/src/test/kotlin/cases/nullable/nullableReturnType.kt
@@ -1,0 +1,6 @@
+package cases.nullable
+
+class NullableReturnType {
+    fun returnObjectType(): String? = null
+    fun returnBasicType(): Int? = null
+}

--- a/src/test/kotlin/cases/protected/protectedInAbstract.kt
+++ b/src/test/kotlin/cases/protected/protectedInAbstract.kt
@@ -2,7 +2,7 @@ package cases.protected
 
 public abstract class PublicAbstractClass protected constructor() {
     protected abstract val protectedVal: Int
-    protected abstract var protectedVar: Any?
+    protected abstract var protectedVar: Any
 
     protected abstract fun protectedFun()
 }

--- a/src/test/kotlin/tests/CasesPublicAPITest.kt
+++ b/src/test/kotlin/tests/CasesPublicAPITest.kt
@@ -40,7 +40,7 @@ class CasesPublicAPITest {
 
     @Test fun nestedClasses() { snapshotAPIAndCompare(testName.methodName) }
 
-    @Test fun nullable() { snapshotAPIAndCompare(testName.methodName) }
+    @Test fun nullable() { snapshotAPIAndCompare(testName.methodName, annotateNullability = true) }
 
     @Test fun private() { snapshotAPIAndCompare(testName.methodName) }
 
@@ -52,7 +52,7 @@ class CasesPublicAPITest {
 
     @Test fun whenMappings() { snapshotAPIAndCompare(testName.methodName) }
 
-    private fun snapshotAPIAndCompare(testClassRelativePath: String) {
+    private fun snapshotAPIAndCompare(testClassRelativePath: String, annotateNullability: Boolean = false) {
         val testClassPaths = baseClassPaths.map { it.resolve(testClassRelativePath) }
         val testClasses = testClassPaths.flatMap { it.listFiles().orEmpty().asIterable() }
         check(testClasses.isNotEmpty()) { "No class files are found in paths: $testClassPaths" }
@@ -60,6 +60,6 @@ class CasesPublicAPITest {
         val testClassStreams = testClasses.asSequence().filter { it.name.endsWith(".class") }.map { it.inputStream() }
         val api = testClassStreams.loadApiFromJvmClasses().filterOutNonPublic()
         val target = baseOutputPath.resolve(testClassRelativePath).resolve(testName.methodName + ".txt")
-        api.dumpAndCompareWith(target)
+        api.dumpAndCompareWith(target, annotateNullability)
     }
 }

--- a/src/test/kotlin/tests/CasesPublicAPITest.kt
+++ b/src/test/kotlin/tests/CasesPublicAPITest.kt
@@ -40,6 +40,8 @@ class CasesPublicAPITest {
 
     @Test fun nestedClasses() { snapshotAPIAndCompare(testName.methodName) }
 
+    @Test fun nullable() { snapshotAPIAndCompare(testName.methodName) }
+
     @Test fun private() { snapshotAPIAndCompare(testName.methodName) }
 
     @Test fun protected() { snapshotAPIAndCompare(testName.methodName) }

--- a/src/test/kotlin/tests/utils.kt
+++ b/src/test/kotlin/tests/utils.kt
@@ -12,13 +12,13 @@ import kotlin.test.fail
 
 private val OVERWRITE_EXPECTED_OUTPUT = System.getProperty("overwrite.output")?.toBoolean() ?: false // use -Doverwrite.output=true
 
-fun List<ClassBinarySignature>.dumpAndCompareWith(to: File) {
+fun List<ClassBinarySignature>.dumpAndCompareWith(to: File, annotateNullability: Boolean) {
     if (!to.exists()) {
         to.parentFile?.mkdirs()
-        to.bufferedWriter().use { dump(to = it) }
+        to.bufferedWriter().use { dump(to = it, annotateNullability = annotateNullability) }
         fail("Expected data file did not exist. Generating: $to")
     } else {
-        val actual = dump(to = StringBuilder())
+        val actual = dump(to = StringBuilder(), annotateNullability = annotateNullability)
         assertEqualsToFile(to, actual)
     }
 }


### PR DESCRIPTION
Hey, we're currently in a situation where we need API compatibility above binary compatibility. BCV is already a pretty good fit for our needs, but nullability support would make it near perfect. So I took a stab at #20. The general approach is to add a `?` to every nullable type: `Ljava/lang/Integer` becomes `Ljava/lang/Integer?`.

Please let me know what you think about this approach. Also since Kotlin isn't my main language any stylistic feedback is also appreciated 😅

Open TODOs:
- [x] Since this is a breaking change we should make it opt-in and add an option to activate it.