### PR TITLE
Properly detect whether the given class is local

### DIFF
--- a/src/main/kotlin/api/AsmMetadataLoading.kt
+++ b/src/main/kotlin/api/AsmMetadataLoading.kt
@@ -36,7 +36,7 @@ fun ClassNode.isEffectivelyPublic(classVisibility: ClassVisibility?) =
 
 
 val ClassNode.innerClassNode: InnerClassNode? get() = innerClasses.singleOrNull { it.name == name }
-fun ClassNode.isLocal() = innerClassNode?.run { innerName == null && outerName == null} ?: false
+fun ClassNode.isLocal() = outerMethod != null
 fun ClassNode.isInner() = innerClassNode != null
 fun ClassNode.isWhenMappings() = isSynthetic(access) && name.endsWith("\$WhenMappings")
 


### PR DESCRIPTION
Parcelize bug explanation:

With Kotlin 1.4.x, the corresponding $Creator class has been generated properly as inner public class and his visibility was dominated by internal outer class

With Kotlin 1.5.0, $Creator is generated as local class within <clinit> block. Local classes do not have the corresponding 'outer_class_info_index' attribute and thus their visibility cannot be dominated by the outer class. But they do not constitute public API anyway. The bug was in incorrect detection on whether the class is local.

Our isLocal check has been broken, but we had an additional guard in the code and also checked kotlinx.metadata.Flag.IS_LOCAL. Parcelize-generated classes lack such metadata and that guard also had failed

Fixes #55