### PR TITLE
Fixed multiple jvm targets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,8 @@ val createClasspathManifest = tasks.register("createClasspathManifest") {
     }
 }
 
+val kotlinVersion: String by project
+
 dependencies {
     implementation(gradleApi())
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.3.0")
@@ -57,7 +59,7 @@ dependencies {
     implementation("org.ow2.asm:asm-tree:9.0")
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
     compileOnly("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.3.61")
-    testRuntimeOnly("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.5.20")
+    testRuntimeOnly("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:$kotlinVersion")
     testImplementation(kotlin("test-junit"))
     "functionalTestImplementation"(files(createClasspathManifest))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,17 @@ tasks.register<Test>("functionalTest") {
 }
 tasks.check { dependsOn(tasks["functionalTest"]) }
 
+val createClasspathManifest = tasks.register("createClasspathManifest") {
+    val outputDir = buildDir.resolve("cpManifests")
+    inputs.files(configurations["testRuntimeClasspath"])
+    outputs.dir(outputDir)
+
+    doLast {
+        outputDir.mkdirs()
+        file(outputDir.resolve("plugin-classpath.txt")).writeText(configurations.testRuntimeClasspath.get().joinToString("\n"))
+    }
+}
+
 dependencies {
     implementation(gradleApi())
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.3.0")
@@ -43,7 +54,9 @@ dependencies {
     implementation("org.ow2.asm:asm-tree:9.0")
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
     compileOnly("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.3.61")
+    testRuntimeOnly("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.5.20")
     testImplementation(kotlin("test-junit"))
+    "functionalTestImplementation"(files(createClasspathManifest))
 
     "functionalTestImplementation"("org.assertj:assertj-core:3.18.1")
     "functionalTestImplementation"(gradleTestKit())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,9 @@ tasks.register<Test>("functionalTest") {
 }
 tasks.check { dependsOn(tasks["functionalTest"]) }
 
+// Hack (from guidance on gradle forums) needed to handle optional plugin dependencies
+// in test code. In test mode classloading works different and classes provided by other
+// plugins are not visible.
 val createClasspathManifest = tasks.register("createClasspathManifest") {
     val outputDir = buildDir.resolve("cpManifests")
     inputs.files(configurations["testRuntimeClasspath"])

--- a/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
@@ -9,7 +9,7 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import java.io.File
 
-open class BaseKotlinGradleTest {
+internal open class BaseKotlinGradleTest {
     @Rule
     @JvmField
     internal val testProjectDir: TemporaryFolder = TemporaryFolder()

--- a/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
@@ -9,7 +9,7 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import java.io.File
 
-internal open class BaseKotlinGradleTest {
+open class BaseKotlinGradleTest {
     @Rule
     @JvmField
     internal val testProjectDir: TemporaryFolder = TemporaryFolder()

--- a/src/functionalTest/kotlin/kotlinx/validation/api/pluginTestRuntimeClasspath.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/pluginTestRuntimeClasspath.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.api
+
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+import java.io.InputStreamReader
+
+
+fun GradleRunner.addPluginTestRuntimeClasspath() = apply {
+
+    val cpResource = javaClass.classLoader.getResourceAsStream("plugin-classpath.txt")
+        ?.let { InputStreamReader(it) }
+        ?: throw IllegalStateException("Could not find classpath resource")
+
+    val pluginClasspath = pluginClasspath + cpResource.readLines().map { File(it) }
+    withPluginClasspath(pluginClasspath)
+
+}

--- a/src/functionalTest/kotlin/kotlinx/validation/api/testDsl.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/testDsl.kt
@@ -35,14 +35,14 @@ internal fun BaseKotlinGradleTest.test(fn: BaseKotlinScope.() -> Unit): GradleRu
 }
 
 /**
- * same as [file][FileContainer.file], but prepends "src/main/java" before given `classFileName`
+ * same as [file][FileContainer.file], but prepends "src/main/kotlin" before given `classFileName`
  */
-internal fun FileContainer.kotlin(classFileName: String, fn: AppendableScope.() -> Unit) {
+internal fun FileContainer.kotlin(classFileName: String, sourceSet:String = "main", fn: AppendableScope.() -> Unit) {
     require(classFileName.endsWith(".kt")) {
         "ClassFileName must end with '.kt'"
     }
 
-    val fileName = "src/main/java/$classFileName"
+    val fileName = "src/${sourceSet}/kotlin/$classFileName"
     file(fileName, fn)
 }
 

--- a/src/functionalTest/kotlin/kotlinx/validation/api/testDsl.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/testDsl.kt
@@ -35,7 +35,7 @@ internal fun BaseKotlinGradleTest.test(fn: BaseKotlinScope.() -> Unit): GradleRu
 }
 
 /**
- * same as [file][FileContainer.file], but prepends "src/main/kotlin" before given `classFileName`
+ * same as [file][FileContainer.file], but prepends "src/${sourceSet}/kotlin" before given `classFileName`
  */
 internal fun FileContainer.kotlin(classFileName: String, sourceSet:String = "main", fn: AppendableScope.() -> Unit) {
     require(classFileName.endsWith(".kt")) {

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultiPlatformSingleJvmTargetTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultiPlatformSingleJvmTargetTest.kt
@@ -7,10 +7,8 @@ package kotlinx.validation.test
 
 import kotlinx.validation.api.*
 import org.assertj.core.api.Assertions.assertThat
-import org.gradle.testkit.runner.GradleRunner
 import org.junit.Test
 import java.io.File
-import java.io.InputStreamReader
 
 internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
     private fun BaseKotlinScope.createProjectHierarchyWithPluginOnRoot() {
@@ -22,50 +20,31 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
         }
     }
 
-    private fun GradleRunner.addClasspathFromPlugin() = apply {
-
-        val cpResource = javaClass.classLoader.getResourceAsStream("plugin-classpath.txt")
-            ?.let { InputStreamReader(it) }
-            ?: throw IllegalStateException("Could not find classpath resource")
-
-        val pluginClasspath = pluginClasspath + cpResource.readLines().map { File(it) }
-        withPluginClasspath(pluginClasspath)
-
-    }
-
     @Test
     fun testApiCheckPasses() {
         val runner = test {
-            createProjectHierarchyWithPluginOnRoot()
-            runner {
-                arguments.add(":apiCheck")
-                arguments.add("--stacktrace")
-            }
-
-            dir("api/") {
-                file("testproject.api") {
-                    resolve("examples/classes/Subsub1Class.dump")
-                    resolve("examples/classes/Subsub2Class.dump")
+                createProjectHierarchyWithPluginOnRoot()
+                runner {
+                    arguments.add(":apiCheck")
+                    arguments.add("--stacktrace")
                 }
-            }
 
-/*
-            dir("api/anotherJvm/") {
-                file("testproject.api") {
-                    resolve("examples/classes/Subsub1Class.dump")
+                dir("api/") {
+                    file("testproject.api") {
+                        resolve("examples/classes/Subsub1Class.dump")
+                        resolve("examples/classes/Subsub2Class.dump")
+                    }
                 }
-            }
-*/
 
-            dir("src/jvmMain/kotlin") {}
-            kotlin("Subsub1Class.kt", "commonMain") {
-                resolve("examples/classes/Subsub1Class.kt")
-            }
-            kotlin("Subsub2Class.kt", "jvmMain") {
-                resolve("examples/classes/Subsub2Class.kt")
-            }
+                dir("src/jvmMain/kotlin") {}
+                kotlin("Subsub1Class.kt", "commonMain") {
+                    resolve("examples/classes/Subsub1Class.kt")
+                }
+                kotlin("Subsub2Class.kt", "jvmMain") {
+                    resolve("examples/classes/Subsub2Class.kt")
+                }
 
-        }.addClasspathFromPlugin()
+            }.addPluginTestRuntimeClasspath()
 
         runner.build().apply {
             assertTaskSuccess(":apiCheck")
@@ -75,29 +54,29 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
     @Test
     fun testApiCheckFails() {
         val runner = test {
-            createProjectHierarchyWithPluginOnRoot()
-            runner {
-                arguments.add("--continue")
-                arguments.add(":check")
-                arguments.add("--stacktrace")
-            }
-
-            dir("api/") {
-                file("testproject.api") {
-                    resolve("examples/classes/Subsub2Class.dump")
-                    resolve("examples/classes/Subsub1Class.dump")
+                createProjectHierarchyWithPluginOnRoot()
+                runner {
+                    arguments.add("--continue")
+                    arguments.add(":check")
+                    arguments.add("--stacktrace")
                 }
-            }
 
-            dir("src/jvmMain/kotlin") {}
-            kotlin("Subsub1Class.kt", "commonMain") {
-                resolve("examples/classes/Subsub1Class.kt")
-            }
-            kotlin("Subsub2Class.kt", "jvmMain") {
-                resolve("examples/classes/Subsub2Class.kt")
-            }
+                dir("api/") {
+                    file("testproject.api") {
+                        resolve("examples/classes/Subsub2Class.dump")
+                        resolve("examples/classes/Subsub1Class.dump")
+                    }
+                }
 
-        }.addClasspathFromPlugin()
+                dir("src/jvmMain/kotlin") {}
+                kotlin("Subsub1Class.kt", "commonMain") {
+                    resolve("examples/classes/Subsub1Class.kt")
+                }
+                kotlin("Subsub2Class.kt", "jvmMain") {
+                    resolve("examples/classes/Subsub2Class.kt")
+                }
+
+            }.addPluginTestRuntimeClasspath()
 
         runner.buildAndFail().apply {
             assertTaskFailure(":jvmApiCheck")
@@ -110,22 +89,23 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
     @Test
     fun testApiDumpPasses() {
         val runner = test {
-            createProjectHierarchyWithPluginOnRoot()
+                createProjectHierarchyWithPluginOnRoot()
 
-            runner {
-                arguments.add(":apiDump")
-                arguments.add("--stacktrace")
-            }
+                runner {
+                    arguments.add(":apiDump")
+                    arguments.add("--stacktrace")
+                }
 
-            dir("src/jvmMain/kotlin") {}
-            kotlin("Subsub1Class.kt", "commonMain") {
-                resolve("examples/classes/Subsub1Class.kt")
-            }
-            kotlin("Subsub2Class.kt", "jvmMain") {
-                resolve("examples/classes/Subsub2Class.kt")
-            }
+                dir("src/jvmMain/kotlin") {}
+                kotlin("Subsub1Class.kt", "commonMain") {
+                    resolve("examples/classes/Subsub1Class.kt")
+                }
+                kotlin("Subsub2Class.kt", "jvmMain") {
+                    resolve("examples/classes/Subsub2Class.kt")
+                }
 
-        }.addClasspathFromPlugin()
+            }.addPluginTestRuntimeClasspath()
+
         runner.build().apply {
             assertTaskSuccess(":apiDump")
 

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
@@ -39,7 +39,6 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
             createProjectHierarchyWithPluginOnRoot()
             runner {
                 arguments.add(":apiCheck")
-                arguments.add(":anotherJvmApiCheck")
             }
 
             dir("api/jvm/") {
@@ -67,6 +66,7 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
 
         runner.build().apply {
             assertTaskSuccess(":apiCheck")
+            assertTaskSuccess(":jvmApiCheck")
             assertTaskSuccess(":anotherJvmApiCheck")
         }
     }
@@ -78,7 +78,6 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
             runner {
                 arguments.add("--continue")
                 arguments.add(":check")
-//                arguments.add(":anotherJvmApiCheck")
             }
 
             dir("api/jvm/") {
@@ -105,7 +104,8 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
         }.addClasspathFromPlugin()
 
         runner.buildAndFail().apply {
-            assertTaskFailure(":apiCheck")
+            assertTaskNotRun(":apiCheck")
+            assertTaskFailure(":jvmApiCheck")
             assertTaskFailure(":anotherJvmApiCheck")
             assertThat(output).contains("API check failed for project testproject")
             assertTaskNotRun(":check")
@@ -119,7 +119,6 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
 
             runner {
                 arguments.add(":apiDump")
-                arguments.add(":anotherJvmApiDump")
             }
 
             dir("src/jvmMain/kotlin") {}
@@ -133,6 +132,7 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
         }.addClasspathFromPlugin()
         runner.build().apply {
             assertTaskSuccess(":apiDump")
+            assertTaskSuccess(":jvmApiDump")
             assertTaskSuccess(":anotherJvmApiDump")
 
             val anotherExpectedApi = readFileList("examples/classes/Subsub1Class.dump")

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
@@ -6,8 +6,11 @@
 package kotlinx.validation.test
 
 import kotlinx.validation.api.*
-import kotlinx.validation.api.BaseKotlinGradleTest
-import org.junit.*
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Test
+import java.io.File
+import java.io.InputStreamReader
 
 internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
     private fun BaseKotlinScope.createProjectHierarchyWithPluginOnRoot() {
@@ -19,9 +22,128 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
         }
     }
 
-    @Test
-    fun testApiCheckPasses() {
+    private fun GradleRunner.addClasspathFromPlugin() = apply {
+
+        val cpResource = javaClass.classLoader.getResourceAsStream("plugin-classpath.txt")
+            ?.let { InputStreamReader(it) }
+            ?: throw IllegalStateException("Could not find classpath resource")
+
+        val pluginClasspath = pluginClasspath + cpResource.readLines().map { File(it) }
+        withPluginClasspath(pluginClasspath)
 
     }
+
+    @Test
+    fun testApiCheckPasses() {
+        val runner = test {
+            createProjectHierarchyWithPluginOnRoot()
+            runner {
+                arguments.add(":apiCheck")
+                arguments.add(":anotherJvmApiCheck")
+            }
+
+            dir("api/jvm/") {
+                file("testproject.api") {
+                    resolve("examples/classes/Subsub1Class.dump")
+                    resolve("examples/classes/Subsub2Class.dump")
+                }
+            }
+
+            dir("api/anotherJvm/") {
+                file("testproject.api") {
+                    resolve("examples/classes/Subsub1Class.dump")
+                }
+            }
+
+            dir("src/jvmMain/kotlin") {}
+            kotlin("Subsub1Class.kt", "commonMain") {
+                resolve("examples/classes/Subsub1Class.kt")
+            }
+            kotlin("Subsub2Class.kt", "jvmMain") {
+                resolve("examples/classes/Subsub2Class.kt")
+            }
+
+        }.addClasspathFromPlugin()
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+            assertTaskSuccess(":anotherJvmApiCheck")
+        }
+    }
+
+    @Test
+    fun testApiCheckFails() {
+        val runner = test {
+            createProjectHierarchyWithPluginOnRoot()
+            runner {
+                arguments.add("--continue")
+                arguments.add(":check")
+//                arguments.add(":anotherJvmApiCheck")
+            }
+
+            dir("api/jvm/") {
+                file("testproject.api") {
+                    resolve("examples/classes/Subsub2Class.dump")
+                    resolve("examples/classes/Subsub1Class.dump")
+                }
+            }
+
+            dir("api/anotherJvm/") {
+                file("testproject.api") {
+                    resolve("examples/classes/Subsub2Class.dump")
+                }
+            }
+
+            dir("src/jvmMain/kotlin") {}
+            kotlin("Subsub1Class.kt", "commonMain") {
+                resolve("examples/classes/Subsub1Class.kt")
+            }
+            kotlin("Subsub2Class.kt", "jvmMain") {
+                resolve("examples/classes/Subsub2Class.kt")
+            }
+
+        }.addClasspathFromPlugin()
+
+        runner.buildAndFail().apply {
+            assertTaskFailure(":apiCheck")
+            assertTaskFailure(":anotherJvmApiCheck")
+            assertThat(output).contains("API check failed for project testproject")
+            assertTaskNotRun(":check")
+        }
+    }
+
+    @Test
+    fun testApiDumpPasses() {
+        val runner = test {
+            createProjectHierarchyWithPluginOnRoot()
+
+            runner {
+                arguments.add(":apiDump")
+                arguments.add(":anotherJvmApiDump")
+            }
+
+            dir("src/jvmMain/kotlin") {}
+            kotlin("Subsub1Class.kt", "commonMain") {
+                resolve("examples/classes/Subsub1Class.kt")
+            }
+            kotlin("Subsub2Class.kt", "jvmMain") {
+                resolve("examples/classes/Subsub2Class.kt")
+            }
+
+        }.addClasspathFromPlugin()
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+            assertTaskSuccess(":anotherJvmApiDump")
+
+            val anotherExpectedApi = readFileList("examples/classes/Subsub1Class.dump")
+            assertThat(anotherApiDump.readText()).isEqualToIgnoringNewLines(anotherExpectedApi)
+
+            val mainExpectedApi = anotherExpectedApi + "\n" + readFileList("examples/classes/Subsub2Class.dump")
+            assertThat(jvmApiDump.readText()).isEqualToIgnoringNewLines(mainExpectedApi)
+        }
+    }
+
+    private val jvmApiDump: File get() = rootProjectDir.resolve("api/jvm/testproject.api")
+    private val anotherApiDump: File get() = rootProjectDir.resolve("api/anotherJvm/testproject.api")
 
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.test
+
+import kotlinx.validation.api.*
+import kotlinx.validation.api.BaseKotlinGradleTest
+import org.junit.*
+
+class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
+    private fun BaseKotlinScope.createProjectHierarchyWithPluginOnRoot() {
+        settingsGradleKts {
+            resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+        }
+        buildGradleKts {
+            resolve("examples/gradle/base/multiplatformWithJvmTargets.gradle.kts")
+        }
+    }
+
+    @Test
+    fun testApiCheckPasses() {
+
+    }
+
+}

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
@@ -22,17 +22,6 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
         }
     }
 
-    private fun GradleRunner.addClasspathFromPlugin() = apply {
-
-        val cpResource = javaClass.classLoader.getResourceAsStream("plugin-classpath.txt")
-            ?.let { InputStreamReader(it) }
-            ?: throw IllegalStateException("Could not find classpath resource")
-
-        val pluginClasspath = pluginClasspath + cpResource.readLines().map { File(it) }
-        withPluginClasspath(pluginClasspath)
-
-    }
-
     @Test
     fun testApiCheckPasses() {
         val runner = test {
@@ -62,7 +51,7 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
                 resolve("examples/classes/Subsub2Class.kt")
             }
 
-        }.addClasspathFromPlugin()
+        }.addPluginTestRuntimeClasspath()
 
         runner.build().apply {
             assertTaskSuccess(":apiCheck")
@@ -101,7 +90,7 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
                 resolve("examples/classes/Subsub2Class.kt")
             }
 
-        }.addClasspathFromPlugin()
+        }.addPluginTestRuntimeClasspath()
 
         runner.buildAndFail().apply {
             assertTaskNotRun(":apiCheck")
@@ -129,7 +118,7 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
                 resolve("examples/classes/Subsub2Class.kt")
             }
 
-        }.addClasspathFromPlugin()
+        }.addPluginTestRuntimeClasspath()
         runner.build().apply {
             assertTaskSuccess(":apiDump")
             assertTaskSuccess(":jvmApiDump")

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
@@ -9,7 +9,7 @@ import kotlinx.validation.api.*
 import kotlinx.validation.api.BaseKotlinGradleTest
 import org.junit.*
 
-class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
+internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
     private fun BaseKotlinScope.createProjectHierarchyWithPluginOnRoot() {
         settingsGradleKts {
             resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")

--- a/src/functionalTest/resources/examples/gradle/base/multiplatformWithJvmTargets.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/multiplatformWithJvmTargets.gradle.kts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016-2021 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+plugins {
+    kotlin("multiplatform") version "1.4.31"
+}
+
+repositories {
+    mavenCentral()
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
+}
+
+kotlin {
+    jvm {
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
+        }
+        testRuns["test"].executionTask.configure {
+            useJUnit()
+        }
+    }
+    jvm("anotherJvm") {
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
+        }
+        testRuns["test"].executionTask.configure {
+            useJUnit()
+        }
+    }
+    sourceSets {
+        val commonMain by getting
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test-common"))
+                implementation(kotlin("test-annotations-common"))
+            }
+        }
+        val jvmMain by getting
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+            }
+        }
+        val jvmFooMain by getting
+        val jvmFooTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+            }
+        }
+    }
+}

--- a/src/functionalTest/resources/examples/gradle/base/multiplatformWithJvmTargets.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/multiplatformWithJvmTargets.gradle.kts
@@ -4,12 +4,12 @@
  */
 
 plugins {
-    kotlin("multiplatform") version "1.4.31"
+    kotlin("multiplatform") version "1.5.20"
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
 repositories {
     mavenCentral()
-    id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
 kotlin {
@@ -33,6 +33,7 @@ kotlin {
         val commonMain by getting
         val commonTest by getting {
             dependencies {
+                implementation(kotlin("stdlib"))
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
             }
@@ -40,11 +41,12 @@ kotlin {
         val jvmMain by getting
         val jvmTest by getting {
             dependencies {
+                implementation(kotlin("stdlib"))
                 implementation(kotlin("test-junit"))
             }
         }
-        val jvmFooMain by getting
-        val jvmFooTest by getting {
+        val anotherJvmMain by getting
+        val anotherJvmTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))
             }

--- a/src/functionalTest/resources/examples/gradle/base/multiplatformWithSingleJvmTarget.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/multiplatformWithSingleJvmTarget.gradle.kts
@@ -22,14 +22,9 @@ kotlin {
                 useJUnit()
             }
         }
-        jvm("anotherJvm") {
-            compilations.all {
-                kotlinOptions.jvmTarget = "1.8"
-            }
-            testRuns["test"].executionTask.configure {
-                useJUnit()
-            }
-        }
+//        android {
+//
+//        }
     }
     sourceSets {
         val commonMain by getting
@@ -44,12 +39,6 @@ kotlin {
         val jvmTest by getting {
             dependencies {
                 implementation(kotlin("stdlib"))
-                implementation(kotlin("test-junit"))
-            }
-        }
-        val anotherJvmMain by getting
-        val anotherJvmTest by getting {
-            dependencies {
                 implementation(kotlin("test-junit"))
             }
         }

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -5,13 +5,22 @@
 
 package kotlinx.validation
 
-import org.gradle.api.*
-import org.gradle.api.plugins.*
-import org.gradle.api.tasks.*
-import org.jetbrains.kotlin.gradle.dsl.*
-import org.jetbrains.kotlin.gradle.plugin.*
-import java.io.*
-import java.net.URLClassLoader
+import org.gradle.api.Action
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.Sync
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import java.io.File
 
 const val API_DIR = "api"
 
@@ -42,7 +51,7 @@ class BinaryCompatibilityValidatorPlugin : Plugin<Project> {
                 if (sourceSet.name != SourceSet.MAIN_SOURCE_SET_NAME) {
                     return@all
                 }
-                project.configureApiTasks(sourceSet, extension)
+                project.configureApiTasks(sourceSet, extension, TargetConfig(project))
             }
         }
 
@@ -60,27 +69,40 @@ class BinaryCompatibilityValidatorPlugin : Plugin<Project> {
             if (project.name in extension.ignoredProjects) return@withPlugin
             val kotlin = project.extensions.getByName("kotlin") as KotlinMultiplatformExtension
 
+
             // Create common tasks for multiplatform
             val commonApiDump = project.tasks.register("apiDump") {
                 it.group = "other"
                 it.description = "Task that collects all target specific dump tasks"
             }
-            val commonApiCheck = project.tasks.register("apiCheck") {
+
+            val commonApiCheck: TaskProvider<Task>? = project.tasks.register("apiCheck") {
                 it.group = "verification"
                 it.description = "Shortcut task that depends on all specific check tasks"
+            }.apply { project.tasks.named("check") { it.dependsOn(this) } }
+
+            val jvmTargetCountProvider = project.provider {
+                kotlin.targets.count {
+                    it.platformType in arrayOf(KotlinPlatformType.jvm,
+                                               KotlinPlatformType.androidJvm)
+                }
             }
-            project.tasks.named("check") { it.dependsOn(commonApiCheck) }
+
+            val dirConfig = jvmTargetCountProvider.map {
+                if (it == 1) DirConfig.COMMON else DirConfig.TARGET_DIR
+            }
 
             kotlin.targets.matching {
                 it.platformType == KotlinPlatformType.jvm || it.platformType == KotlinPlatformType.androidJvm
             }.all { target ->
+                val targetConfig = TargetConfig(project, target.name, dirConfig)
                 if (target.platformType == KotlinPlatformType.jvm) {
                     target.compilations.matching { it.name == "main" }.all {
-                        project.configureKotlinCompilation(it, extension, target, commonApiDump, commonApiCheck)
+                        project.configureKotlinCompilation(it, extension, targetConfig, commonApiDump, commonApiCheck)
                     }
                 } else if (target.platformType == KotlinPlatformType.androidJvm) {
                     target.compilations.matching { it.name == "release" }.all {
-                        project.configureKotlinCompilation(it, extension, target, commonApiDump, commonApiCheck, useOutput = true)
+                        project.configureKotlinCompilation(it, extension, targetConfig, commonApiDump, commonApiCheck, useOutput = true)
                     }
                 }
             }
@@ -88,45 +110,75 @@ class BinaryCompatibilityValidatorPlugin : Plugin<Project> {
     }
 }
 
-fun KotlinTarget?.apiTaskName(suffix: String) = when (this?.name) {
-    null,
-    "jvm" -> "api$suffix"
-    else  -> "${name}Api$suffix"
+private class TargetConfig constructor(
+    project: Project,
+    val targetName: String? = null,
+    private val dirConfig: Provider<DirConfig>? = null,
+) {
+
+    private val API_DIR_PROVIDER = project.provider { API_DIR }
+
+    fun apiTaskName(suffix: String) = when (targetName) {
+        null, "" -> "api$suffix"
+        else     -> "${targetName}Api$suffix"
+    }
+
+    val apiDir
+        get() = dirConfig?.map { dirConfig ->
+            when {
+                dirConfig == DirConfig.COMMON || (
+                        dirConfig == DirConfig.AUTO &&
+                                (targetName == null ||
+                                        targetName == "jvm"))
+                     -> API_DIR
+
+                else -> "$API_DIR/$targetName"
+            }
+        } ?: API_DIR_PROVIDER
+
 }
 
-val KotlinTarget?.apiDir
-    get() = when (this?.name) {
-        null -> API_DIR
-        else -> "$API_DIR/$name"
-    }
+
+enum class DirConfig {
+    COMMON,
+    TARGET_DIR,
+    AUTO
+}
 
 private fun Project.configureKotlinCompilation(
     compilation: KotlinCompilation<KotlinCommonOptions>,
     extension: ApiValidationExtension,
-    target: KotlinTarget? = null,
+    targetConfig: TargetConfig = TargetConfig(this),
     commonApiDump: TaskProvider<Task>? = null,
     commonApiCheck: TaskProvider<Task>? = null,
-    useOutput: Boolean = false
+    useOutput: Boolean = false,
 ) {
     val projectName = project.name
-    val apiBuildDir = file(buildDir.resolve(target.apiDir))
-    val apiBuild = task<KotlinApiBuildTask>(target.apiTaskName("Build"), extension) {
+    val apiDirProvider = targetConfig.apiDir
+    val apiBuildDir = apiDirProvider.map { buildDir.resolve(it) }
+
+    val apiBuild = task<KotlinApiBuildTask>(targetConfig.apiTaskName("Build"), extension) {
         // Do not enable task for empty umbrella modules
-        isEnabled = apiCheckEnabled(extension) && compilation.allKotlinSourceSets.any { it.kotlin.srcDirs.any { it.exists() } }
+        isEnabled =
+            apiCheckEnabled(extension) && compilation.allKotlinSourceSets.any { it.kotlin.srcDirs.any { it.exists() } }
         // 'group' is not specified deliberately so it will be hidden from ./gradlew tasks
         description =
             "Builds Kotlin API for 'main' compilations of $projectName. Complementary task and shouldn't be called manually"
         if (useOutput) {
             // Workaround for #4
-            inputClassesDirs = files(provider<Any> { if (isEnabled) compilation.output.classesDirs else emptyList<Any>() })
-            inputDependencies = files(provider<Any> { if (isEnabled) compilation.output.classesDirs else emptyList<Any>() })
+            inputClassesDirs =
+                files(provider<Any> { if (isEnabled) compilation.output.classesDirs else emptyList<Any>() })
+            inputDependencies =
+                files(provider<Any> { if (isEnabled) compilation.output.classesDirs else emptyList<Any>() })
         } else {
-            inputClassesDirs = files(provider<Any> { if (isEnabled) compilation.output.classesDirs else emptyList<Any>() })
-            inputDependencies = files(provider<Any> { if (isEnabled) compilation.compileDependencyFiles else emptyList<Any>() })
+            inputClassesDirs =
+                files(provider<Any> { if (isEnabled) compilation.output.classesDirs else emptyList<Any>() })
+            inputDependencies =
+                files(provider<Any> { if (isEnabled) compilation.compileDependencyFiles else emptyList<Any>() })
         }
-        outputApiDir = apiBuildDir
+        outputApiDir = apiBuildDir.get()
     }
-    configureCheckTasks(apiBuildDir, apiBuild, extension, target, commonApiDump, commonApiCheck)
+    configureCheckTasks(apiBuildDir, apiBuild, extension, targetConfig, commonApiDump, commonApiCheck)
 }
 
 val Project.sourceSets: SourceSetContainer
@@ -138,56 +190,63 @@ fun Project.apiCheckEnabled(extension: ApiValidationExtension): Boolean =
 private fun Project.configureApiTasks(
     sourceSet: SourceSet,
     extension: ApiValidationExtension,
-    target: KotlinTarget? = null
+    targetConfig: TargetConfig = TargetConfig(this),
 ) {
     val projectName = project.name
-    val apiBuildDir = file(buildDir.resolve(target.apiDir))
-    val apiBuild = task<KotlinApiBuildTask>(target.apiTaskName("Build"), extension) {
+    val apiBuildDir = targetConfig.apiDir.map { buildDir.resolve(it) }
+    val apiBuild = task<KotlinApiBuildTask>(targetConfig.apiTaskName("Build"), extension) {
         isEnabled = apiCheckEnabled(extension)
         // 'group' is not specified deliberately so it will be hidden from ./gradlew tasks
         description =
             "Builds Kotlin API for 'main' compilations of $projectName. Complementary task and shouldn't be called manually"
         inputClassesDirs = files(provider<Any> { if (isEnabled) sourceSet.output.classesDirs else emptyList<Any>() })
         inputDependencies = files(provider<Any> { if (isEnabled) sourceSet.output.classesDirs else emptyList<Any>() })
-        outputApiDir = apiBuildDir
+        outputApiDir = apiBuildDir.get()
     }
 
-    configureCheckTasks(apiBuildDir, apiBuild, extension, target)
+    configureCheckTasks(apiBuildDir, apiBuild, extension, targetConfig)
 }
 
 private fun Project.configureCheckTasks(
-    apiBuildDir: File,
+    apiBuildDir: Provider<File>,
     apiBuild: TaskProvider<KotlinApiBuildTask>,
     extension: ApiValidationExtension,
-    target: KotlinTarget? = null,
+    targetConfig: TargetConfig,
     commonApiDump: TaskProvider<Task>? = null,
-    commonApiCheck: TaskProvider<Task>? = null
+    commonApiCheck: TaskProvider<Task>? = null,
 ) {
     val projectName = project.name
-    val apiCheckDir = file(projectDir.resolve(target.apiDir))
-    val apiCheck = task<ApiCompareCompareTask>(target.apiTaskName("Check")) {
+    val apiCheckDir = targetConfig.apiDir.map {
+        projectDir.resolve(it).also { r ->
+            logger.lifecycle("Configuring api for ${targetConfig.targetName} to $r")
+        }
+    }
+    val apiCheck = task<ApiCompareCompareTask>(targetConfig.apiTaskName("Check")) {
         isEnabled = apiCheckEnabled(extension) && apiBuild.map { it.enabled }.getOrElse(true)
         group = "verification"
         description = "Checks signatures of public API against the golden value in API folder for $projectName"
-        projectApiDir = if (apiCheckDir.exists()) {
-            apiCheckDir
-        } else {
-            nonExistingProjectApiDir = apiCheckDir.toString()
-            null
+        run {
+            val d = apiCheckDir.get()
+            projectApiDir = if (d.exists()) {
+                d
+            } else {
+                nonExistingProjectApiDir = d.toString()
+                null
+            }
+            this.apiBuildDir = apiBuildDir.get()
         }
-        this.apiBuildDir = apiBuildDir
         dependsOn(apiBuild)
     }
 
-    val apiDump = task<Sync>(target.apiTaskName("Dump")) {
+    val apiDump = task<Sync>(targetConfig.apiTaskName("Dump")) {
         isEnabled = apiCheckEnabled(extension) && apiBuild.map { it.enabled }.getOrElse(true)
         group = "other"
-        description = "Syncs API from build dir to ${target.apiDir} dir for $projectName"
+        description = "Syncs API from build dir to ${targetConfig.apiDir} dir for $projectName"
         from(apiBuildDir)
         into(apiCheckDir)
         dependsOn(apiBuild)
         doFirst {
-            apiCheckDir.mkdirs()
+            apiCheckDir.get().mkdirs()
         }
     }
 
@@ -201,13 +260,13 @@ private fun Project.configureCheckTasks(
 
 inline fun <reified T : Task> Project.task(
     name: String,
-    noinline configuration: T.() -> Unit
+    noinline configuration: T.() -> Unit,
 ): TaskProvider<T> = tasks.register(name, T::class.java, Action(configuration))
 
 inline fun <reified T : Task> Project.task(
     name: String,
     extension: ApiValidationExtension,
-    noinline configuration: T.() -> Unit
+    noinline configuration: T.() -> Unit,
 ): TaskProvider<T> = tasks.register(name, T::class.java, extension).also {
     it.configure(Action(configuration))
 }

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -126,11 +126,7 @@ private class TargetConfig constructor(
     val apiDir
         get() = dirConfig?.map { dirConfig ->
             when {
-                dirConfig == DirConfig.COMMON || (
-                        dirConfig == DirConfig.AUTO &&
-                                (targetName == null ||
-                                        targetName == "jvm"))
-                     -> API_DIR
+                dirConfig == DirConfig.COMMON -> API_DIR
 
                 else -> "$API_DIR/$targetName"
             }
@@ -142,7 +138,6 @@ private class TargetConfig constructor(
 enum class DirConfig {
     COMMON,
     TARGET_DIR,
-    AUTO
 }
 
 private fun Project.configureKotlinCompilation(


### PR DESCRIPTION
This is a rework of the multiple-jvm-targets branch that actually works. The testing is "fixed" and the implementation is fixed. Note that this is not 100% compatible with existing projects as it uses target-specific subdirectories (only for multiplatform projects).