### PR TITLE
Fail-fast if it's not possible to read @Metadata from Kotlin class in…

### DIFF
--- a/src/main/kotlin/api/KotlinMetadataVisibilities.kt
+++ b/src/main/kotlin/api/KotlinMetadataVisibilities.kt
@@ -66,7 +66,7 @@ val ClassNode.kotlinMetadata: KotlinClassMetadata?
                 Incompatible version of Kotlin metadata.
                 Maximal supported Kotlin metadata version: ${COMPATIBLE_METADATA_VERSION.joinToString(".")},
                 $name Kotlin metadata version: ${header.metadataVersion.joinToString(".")}.
-                As a workaround, it is possible to manually update 'kotlinx-metadata' version in your project.
+                As a workaround, it is possible to manually update 'kotlinx-metadata-jvm' version in your project.
             """.trimIndent()
             )
     }

--- a/src/main/kotlin/api/KotlinMetadataVisibilities.kt
+++ b/src/main/kotlin/api/KotlinMetadataVisibilities.kt
@@ -7,6 +7,7 @@ package kotlinx.validation.api
 
 import kotlinx.metadata.*
 import kotlinx.metadata.jvm.*
+import kotlinx.metadata.jvm.KotlinClassHeader.Companion.COMPATIBLE_METADATA_VERSION
 import org.objectweb.asm.tree.ClassNode
 
 class ClassVisibility(
@@ -60,6 +61,14 @@ val ClassNode.kotlinMetadata: KotlinClassMetadata?
             )
         }
         return KotlinClassMetadata.read(header)
+            ?: error(
+                """
+                Incompatible version of Kotlin metadata.
+                Maximal supported Kotlin metadata version: ${COMPATIBLE_METADATA_VERSION.joinToString(".")},
+                $name Kotlin metadata version: ${header.metadataVersion.joinToString(".")}.
+                As a workaround, it is possible to manually update 'kotlinx-metadata' version in your project.
+            """.trimIndent()
+            )
     }
 
 


### PR DESCRIPTION
…stead of producing incorrect visibilities and dumps