### PR TITLE
Publish filterOutAnnotated as `ExternalApi`

### DIFF
--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -82,7 +82,8 @@ public fun Sequence<InputStream>.loadApiFromJvmClasses(visibilityFilter: (String
         }
 }
 
-internal fun List<ClassBinarySignature>.filterOutAnnotated(targetAnnotations: Set<String>): List<ClassBinarySignature> {
+@ExternalApi
+public fun List<ClassBinarySignature>.filterOutAnnotated(targetAnnotations: Set<String>): List<ClassBinarySignature> {
     if (targetAnnotations.isEmpty()) return this
     return filter {
         it.annotations.all { ann -> !targetAnnotations.any { ann.refersToName(it) }  }


### PR DESCRIPTION
This method is intended to be used to verify the
`kotlin-gradle-plugin-idea` module in kotlin.git
This method has special APIs for the Gradle plugin
only which are not needed to be kept stable