### PR TITLE
Fix task name in error message for missing .api files (and add some hints)

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/api/Assert.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/Assert.kt
@@ -5,6 +5,7 @@
 
 package kotlinx.validation.api
 
+import org.assertj.core.api.Assertions
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import kotlin.test.assertEquals
@@ -34,4 +35,8 @@ private fun BuildResult.assertTaskOutcome(taskOutcome: TaskOutcome, taskName: St
  */
 internal fun BuildResult.assertTaskNotRun(taskName: String) {
     assertNull(task(taskName), "task $taskName was not expected to be run")
+}
+
+internal fun BuildResult.assertOutputContains(text: String) {
+    Assertions.assertThat(output).contains(text)
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
@@ -17,4 +17,7 @@ internal open class BaseKotlinGradleTest {
     internal val rootProjectDir: File get() = testProjectDir.root
 
     internal val rootProjectApiDump: File get() = rootProjectDir.resolve("api/${rootProjectDir.name}.api")
+
+    // Not using a simple string here to ensure the correct file separator is used on every system
+    internal val rootProjectApiDumpRelative: File get() = rootProjectApiDump.relativeTo(rootProjectDir)
 }

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -243,6 +243,19 @@ private fun Project.configureCheckTasks(
             logger.debug("Configuring api for ${targetConfig.targetName ?: "jvm"} to $r")
         }
     }
+
+    val apiDump = task<Sync>(targetConfig.apiTaskName("Dump")) {
+        isEnabled = apiCheckEnabled(extension) && apiBuild.map { it.enabled }.getOrElse(true)
+        group = "other"
+        description = "Syncs API from build dir to ${targetConfig.apiDir} dir for $projectName"
+        from(apiBuildDir)
+        into(apiCheckDir)
+        dependsOn(apiBuild)
+        doFirst {
+            apiCheckDir.get().mkdirs()
+        }
+    }
+
     val apiCheck = task<ApiCompareCompareTask>(targetConfig.apiTaskName("Check")) {
         isEnabled = apiCheckEnabled(extension) && apiBuild.map { it.enabled }.getOrElse(true)
         group = "verification"
@@ -256,20 +269,9 @@ private fun Project.configureCheckTasks(
                 null
             }
             this.apiBuildDir = apiBuildDir.get()
+            dumpTaskFqn = apiDump.get().path
         }
         dependsOn(apiBuild)
-    }
-
-    val apiDump = task<Sync>(targetConfig.apiTaskName("Dump")) {
-        isEnabled = apiCheckEnabled(extension) && apiBuild.map { it.enabled }.getOrElse(true)
-        group = "other"
-        description = "Syncs API from build dir to ${targetConfig.apiDir} dir for $projectName"
-        from(apiBuildDir)
-        into(apiCheckDir)
-        dependsOn(apiBuild)
-        doFirst {
-            apiCheckDir.get().mkdirs()
-        }
     }
 
     commonApiDump?.configure { it.dependsOn(apiDump) }


### PR DESCRIPTION
Resolves the task name bug mentioned in this issue: https://github.com/Kotlin/binary-compatibility-validator/issues/76

And also provides some hints about project renames (when a file is found with an incorrect name) and suggest deletion in case the rename is case-change-only.

I'm sorry if the diff is a bit chaotic, I tried to simplify some stuff in the implementation that accesses the files. Not sure why the objectfactory / filetrees were used there instead of plain listFiles().