### PR TITLE
Do not expose kotlin-stdlib in dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,5 @@ group=org.jetbrains.kotlinx
 
 kotlinVersion=1.6.0
 pluginPublishVersion=0.10.1
+
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
Like for the Kotlin Gradle Plugin [YouTrack comment](https://youtrack.jetbrains.com/issue/KT-41142), there is no need to expose `kotlin-stdlib` as a runtime dependency as Gradle will provide its own version on the classpath. 

This fixes some `Runtime JAR files in the classpath should have the same version` warnings.