### PR TITLE
Also exclude transitive usages of the stdlib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,12 @@ val createClasspathManifest = tasks.register("createClasspathManifest") {
 
 val kotlinVersion: String by project
 
+configurations.implementation {
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
+}
+
 dependencies {
     implementation(gradleApi())
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.4.2")


### PR DESCRIPTION
Follow up from https://github.com/Kotlin/binary-compatibility-validator/pull/80

It turns out the `stdlib` was also transitively pulled by `kotlinx-metadata-jvm` so I excluded it from the `implementation` configuration altogether.