### PR TITLE
Support reading classes from resulting jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,26 @@ apiValidation {
 }
 ```
 
+### Producing dump of a jar
+
+By default, binary compatibility validator analyzes project output class files from `build/classes` directory when building an API dump.
+If you pack these classes into an output jar not in a regular way, for example, by excluding certain classes, applying `shadow` plugin, and so on,
+the API dump built from the original class files may no longer reflect the resulting jar contents accurately.
+In that case, it makes sense to use the resulting jar as an input of the `apuBuild` task:
+
+Kotlin
+```kotlin
+tasks {
+    apiBuild {
+        // "jar" here is the name of the default Jar task producing the resulting jar file
+        // in a multiplatform project it can be named "jvmJar"
+        // if you applied the shadow plugin, it creates the "shadowJar" task that produces the transformed jar
+        inputJar.value(jar.flatMap { it.archiveFile })
+    }
+}
+```
+
+
 ### Workflow
 
 When starting to validate your library public API, we recommend the following workflow:

--- a/src/functionalTest/kotlin/kotlinx/validation/test/InputJarTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/InputJarTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.test
+
+import kotlinx.validation.api.*
+import org.junit.*
+
+class InputJarTest : BaseKotlinGradleTest() {
+
+    @Test
+    fun testOverrideInputJar() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/jarAsInput/inputJar.gradle.kts")
+            }
+
+            kotlin("Properties.kt") {
+                resolve("examples/classes/Properties.kt")
+            }
+
+            apiFile(projectName = rootProjectDir.name) {
+                resolve("examples/classes/PropertiesJarTransformed.dump")
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":jar")
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+}

--- a/src/functionalTest/resources/examples/classes/PropertiesJarTransformed.dump
+++ b/src/functionalTest/resources/examples/classes/PropertiesJarTransformed.dump
@@ -1,0 +1,8 @@
+public final class foo/ClassWithProperties {
+	public fun <init> ()V
+	public final fun getBar1 ()I
+	public final fun getBar2 ()I
+	public final fun setBar1 (I)V
+	public final fun setBar2 (I)V
+}
+

--- a/src/functionalTest/resources/examples/gradle/configuration/jarAsInput/inputJar.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/jarAsInput/inputJar.gradle.kts
@@ -1,0 +1,9 @@
+tasks {
+    jar {
+        exclude("foo/HiddenField.class")
+        exclude("foo/HiddenProperty.class")
+    }
+    apiBuild {
+        inputJar.value(jar.flatMap { it.archiveFile })
+    }
+}

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -199,15 +199,18 @@ private fun Project.configureKotlinCompilation(
                 files(provider<Any> { if (isEnabled) compilation.compileDependencyFiles else emptyList<Any>() })
         }
         outputApiDir = apiBuildDir.get()
-        ignoredPackages = extension.ignoredPackages
-        ignoredClasses = extension.ignoredClasses
-        nonPublicMarkers = extension.nonPublicMarkers
     }
     configureCheckTasks(apiBuildDir, apiBuild, extension, targetConfig, commonApiDump, commonApiCheck)
 }
 
 val Project.sourceSets: SourceSetContainer
     get() = convention.getPlugin(JavaPluginConvention::class.java).sourceSets
+
+internal val Project.apiValidationExtensionOrNull: ApiValidationExtension?
+    get() =
+        generateSequence(this) { it.parent }
+            .map { it.extensions.findByType(ApiValidationExtension::class.java) }
+            .firstOrNull { it != null }
 
 fun apiCheckEnabled(projectName: String, extension: ApiValidationExtension): Boolean =
     projectName !in extension.ignoredProjects && !extension.validationDisabled
@@ -227,9 +230,6 @@ private fun Project.configureApiTasks(
         inputClassesDirs = files(provider<Any> { if (isEnabled) sourceSet.output.classesDirs else emptyList<Any>() })
         inputDependencies = files(provider<Any> { if (isEnabled) sourceSet.output.classesDirs else emptyList<Any>() })
         outputApiDir = apiBuildDir.get()
-        ignoredPackages = extension.ignoredPackages
-        ignoredClasses = extension.ignoredClasses
-        nonPublicMarkers = extension.nonPublicMarkers
     }
 
     configureCheckTasks(apiBuildDir, apiBuild, extension, targetConfig)

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -62,10 +62,10 @@ open class KotlinApiBuildTask @Inject constructor(
         outputApiDir.mkdirs()
 
         val inputClassesDirs = inputClassesDirs
-        if (listOfNotNull(inputClassesDirs, inputJar.orNull).size != 1) {
-            throw GradleException("KotlinApiBuildTask should have either inputClassesDirs, or inputJar properties set")
-        }
         val signatures = when {
+            // inputJar takes precedence if specified
+            inputJar.isPresent ->
+                JarFile(inputJar.get().asFile).use { it.loadApiFromJvmClasses() }
             inputClassesDirs != null ->
                 inputClassesDirs.asFileTree.asSequence()
                     .filter {
@@ -73,11 +73,8 @@ open class KotlinApiBuildTask @Inject constructor(
                     }
                     .map { it.inputStream() }
                     .loadApiFromJvmClasses()
-            inputJar.isPresent ->
-                JarFile(inputJar.get().asFile)
-                    .loadApiFromJvmClasses()
             else ->
-                error("Unreachable")
+                throw GradleException("KotlinApiBuildTask should have either inputClassesDirs, or inputJar property set")
         }
 
 

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -16,6 +16,8 @@ import javax.inject.Inject
 open class KotlinApiBuildTask @Inject constructor(
 ) : DefaultTask() {
 
+    private val extension = project.apiValidationExtensionOrNull
+
     @InputFiles
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -33,14 +35,23 @@ open class KotlinApiBuildTask @Inject constructor(
     @OutputDirectory
     lateinit var outputApiDir: File
 
+    private var _ignoredPackages: Set<String>? = null
     @get:Input
-    var ignoredPackages : Set<String> = emptySet()
+    var ignoredPackages : Set<String>
+        get() = _ignoredPackages ?: extension?.ignoredPackages ?: emptySet()
+        set(value) { _ignoredPackages = value }
 
+    private var _nonPublicMarkes: Set<String>? = null
     @get:Input
-    var nonPublicMarkers : Set<String> = emptySet()
+    var nonPublicMarkers : Set<String>
+        get() = _nonPublicMarkes ?: extension?.nonPublicMarkers ?: emptySet()
+        set(value) { _nonPublicMarkes = value }
 
+    private var _ignoredClasses: Set<String>? = null
     @get:Input
-    var ignoredClasses : Set<String> = emptySet()
+    var ignoredClasses : Set<String>
+        get() = _ignoredClasses ?: extension?.ignoredClasses ?: emptySet()
+        set(value) { _ignoredClasses = value }
 
     @get:Internal
     internal val projectName = project.name

--- a/src/main/kotlin/KotlinApiCompareTask.kt
+++ b/src/main/kotlin/KotlinApiCompareTask.kt
@@ -32,6 +32,16 @@ open class KotlinApiCompareTask @Inject constructor(private val objects: ObjectF
     @Optional
     var nonExistingProjectApiDir: String? = null
 
+    fun compareApiDumps(apiReferenceDir: File, apiBuildDir: File) {
+        if (apiReferenceDir.exists()) {
+            projectApiDir = apiReferenceDir
+        } else {
+            projectApiDir = null
+            nonExistingProjectApiDir = apiReferenceDir.toString()
+        }
+        this.apiBuildDir = apiBuildDir
+    }
+
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
     lateinit var apiBuildDir: File


### PR DESCRIPTION
... and allow configuring tasks without link to `ApiValidationExtension`

An example of using manually configured tasks in a project without applying the plugin:
```
plugins {
    id("org.jetbrains.kotlinx.binary-compatibility-validator") version ... apply false
}

tasks {
    val apiBuildDir = file("build/api")
    val apiReferenceDir = file("api")
    val apiBuild by registering(KotlinApiBuildTask::class) {
        outputApiDir = apiBuildDir
        inputJar.value(jar.flatMap { it.archiveFile })
        inputDependencies = files()
    }
    val apiDump by registering(Sync::class) {
        dependsOn(apiBuild)
        from(apiBuildDir)
        into(apiReferenceDir)
    }
    val apiCompare by registering(KotlinApiCompareTask::class) {
        dependsOn(apiBuild)
        compareApiDumps(apiReferenceDir, apiBuildDir)
    }
    check { dependsOn(apiCompare) }
}
```