### PR TITLE
AndroidLibrarySupport: Add Java Android library support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.gradle.publish.*
 import kotlinx.validation.build.*
-import org.jetbrains.kotlin.gradle.tasks.*
 
 plugins {
     kotlin("jvm")
@@ -64,7 +63,7 @@ val createClasspathManifest = tasks.register("createClasspathManifest") {
 }
 
 val kotlinVersion: String by project
-val androidGradlePluginVersion: String = "7.2.2"
+val androidGradlePluginVersion: String = "7.3.1"
 
 configurations.implementation {
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
@@ -79,7 +78,7 @@ dependencies {
     implementation("org.ow2.asm:asm-tree:9.2")
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
     compileOnly("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.6.0")
-//    compileOnly("com.android.tools.build:gradle:${androidGradlePluginVersion}")
+    compileOnly("com.android.tools.build:gradle:${androidGradlePluginVersion}")
 
     // The test needs the full kotlin multiplatform plugin loaded as it has no visibility of previously loaded plugins,
     // unlike the regular way gradle loads plugins.

--- a/src/functionalTest/resources/examples/gradle/base/androidJavaLibrary.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/androidJavaLibrary.gradle.kts
@@ -5,7 +5,6 @@
 
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
 android {

--- a/src/functionalTest/resources/examples/gradle/base/androidJavaLibraryWithPlugin.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/androidJavaLibraryWithPlugin.gradle.kts
@@ -5,12 +5,12 @@
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
 android {
 
-    namespace = "org.jetbrains.kotlinx.android.kotlin.library"
+    namespace = "org.jetbrains.kotlinx.android.java.library"
 
     compileSdk = 32
 
@@ -23,7 +23,7 @@ android {
     }
 
     buildTypes {
-        getByName("release") {
+        release {
             isMinifyEnabled = true
             proguardFiles(
                     getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/src/functionalTest/resources/examples/gradle/base/androidKotlinLibraryWithPlugin.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/androidKotlinLibraryWithPlugin.gradle.kts
@@ -6,6 +6,7 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
 android {

--- a/src/functionalTest/resources/examples/gradle/base/androidProjectRootWithPlugin.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/androidProjectRootWithPlugin.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("com.android.application").version("7.2.2").apply(false)
+    id("com.android.library").version("7.2.2").apply(false)
+    id("org.jetbrains.kotlin.android").version("1.7.10").apply(false)
+    id("org.jetbrains.kotlinx.binary-compatibility-validator").apply(true)
+}
+
+tasks.register("clean", Delete::class) {
+    delete(rootProject.buildDir)
+}


### PR DESCRIPTION
Fixes: #94

This time I applied the plugin to the root project only and it worked as expected, added additional functional tests for the plugin-on-root cases, all seems to be fine on my side. I did not have time to clean-up the code as much as I wanted to, so it might look a bit messy right now. If needed, I can refactor after you confirm that the problem is indeed resolved for other libraries you've tested.