### PR TITLE
Add ability to turn on cheking only changes and deletes in api

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.12.1-SNAPSHOT
+version=0.13.0-SNAPSHOT
 group=org.jetbrains.kotlinx
 
 kotlinVersion=1.6.0

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -7,6 +7,13 @@ package kotlinx.validation
 
 open class ApiValidationExtension {
 
+
+    /**
+     * Disables validation of new public elements.
+     * It will check only changes and deletes to current api.
+     */
+    public var shouldCheckNewPublicElements = true
+
     /**
      * Disables API validation checks completely.
      */

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -149,7 +149,7 @@ private class TargetConfig constructor(
 
     fun apiTaskName(suffix: String) = when (targetName) {
         null, "" -> "api$suffix"
-        else     -> "${targetName}Api$suffix"
+        else -> "${targetName}Api$suffix"
     }
 
     val apiDir
@@ -262,7 +262,11 @@ private fun Project.configureCheckTasks(
         isEnabled = apiCheckEnabled(projectName, extension) && apiBuild.map { it.enabled }.getOrElse(true)
         group = "verification"
         description = "Checks signatures of public API against the golden value in API folder for $projectName"
-        compareApiDumps(apiReferenceDir = apiCheckDir.get(), apiBuildDir = apiBuildDir.get())
+        compareApiDumps(
+            apiReferenceDir = apiCheckDir.get(),
+            apiBuildDir = apiBuildDir.get(),
+            shouldCheckNewPublicElements = extension.shouldCheckNewPublicElements
+        )
         dependsOn(apiBuild)
     }
 


### PR DESCRIPTION
In our library, we want ability to turn on checking only delete and update changes (not creating new classes for example).
Added this ability to plugin