### PR TITLE
Support for explicit public API markers

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/test/MixedMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MixedMarkersTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.test
+
+import kotlinx.validation.api.*
+import kotlinx.validation.api.buildGradleKts
+import kotlinx.validation.api.kotlin
+import kotlinx.validation.api.resolve
+import kotlinx.validation.api.test
+import org.junit.Test
+
+class MixedMarkersTest : BaseKotlinGradleTest() {
+
+    @Test
+    fun testMixedMarkers() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/publicMarkers/mixedMarkers.gradle.kts")
+            }
+
+            kotlin("MixedAnnotations.kt") {
+                resolve("examples/classes/MixedAnnotations.kt")
+            }
+
+            apiFile(projectName = rootProjectDir.name) {
+                resolve("examples/classes/MixedAnnotations.dump")
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.withDebug(true).build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+}

--- a/src/functionalTest/kotlin/kotlinx/validation/test/PublicMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/PublicMarkersTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.test
+
+import kotlinx.validation.api.*
+import kotlinx.validation.api.buildGradleKts
+import kotlinx.validation.api.kotlin
+import kotlinx.validation.api.resolve
+import kotlinx.validation.api.test
+import org.junit.Test
+
+class PublicMarkersTest : BaseKotlinGradleTest() {
+
+    @Test
+    fun testPublicMarkers() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/publicMarkers/markers.gradle.kts")
+            }
+
+            kotlin("ClassWithPublicMarkers.kt") {
+                resolve("examples/classes/ClassWithPublicMarkers.kt")
+            }
+
+            kotlin("ClassInPublicPackage.kt") {
+                resolve("examples/classes/ClassInPublicPackage.kt")
+            }
+
+            apiFile(projectName = rootProjectDir.name) {
+                resolve("examples/classes/ClassWithPublicMarkers.dump")
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.withDebug(true).build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+}

--- a/src/functionalTest/resources/examples/classes/ClassInPublicPackage.kt
+++ b/src/functionalTest/resources/examples/classes/ClassInPublicPackage.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package foo.api
+
+class ClassInPublicPackage {
+    class Inner
+}

--- a/src/functionalTest/resources/examples/classes/ClassWithPublicMarkers.dump
+++ b/src/functionalTest/resources/examples/classes/ClassWithPublicMarkers.dump
@@ -1,0 +1,23 @@
+public final class foo/ClassWithPublicMarkers {
+	public final fun getBar1 ()I
+	public final fun getBar2 ()I
+	public final fun setBar1 (I)V
+	public final fun setBar2 (I)V
+}
+
+public final class foo/ClassWithPublicMarkers$MarkedClass {
+	public fun <init> ()V
+	public final fun getBar1 ()I
+}
+
+public abstract interface annotation class foo/PublicClass : java/lang/annotation/Annotation {
+}
+
+public final class foo/api/ClassInPublicPackage {
+	public fun <init> ()V
+}
+
+public final class foo/api/ClassInPublicPackage$Inner {
+	public fun <init> ()V
+}
+

--- a/src/functionalTest/resources/examples/classes/ClassWithPublicMarkers.kt
+++ b/src/functionalTest/resources/examples/classes/ClassWithPublicMarkers.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package foo
+
+@Target(AnnotationTarget.CLASS)
+annotation class PublicClass
+
+@Target(AnnotationTarget.FIELD)
+annotation class PublicField
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class PublicProperty
+
+public class ClassWithPublicMarkers {
+    @PublicField
+    var bar1 = 42
+
+    @PublicProperty
+    var bar2 = 42
+
+    @PublicClass
+    class MarkedClass {
+        val bar1 = 41
+    }
+
+    var notMarkedPublic = 42
+
+    class NotMarkedClass
+}

--- a/src/functionalTest/resources/examples/classes/MixedAnnotations.dump
+++ b/src/functionalTest/resources/examples/classes/MixedAnnotations.dump
@@ -1,0 +1,5 @@
+public final class mixed/MarkedPublicWithPrivateMembers {
+	public fun <init> ()V
+	public final fun otherFun ()V
+}
+

--- a/src/functionalTest/resources/examples/classes/MixedAnnotations.kt
+++ b/src/functionalTest/resources/examples/classes/MixedAnnotations.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package mixed
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+annotation class PublicApi
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+annotation class PrivateApi
+
+@PublicApi
+class MarkedPublicWithPrivateMembers {
+    @PrivateApi
+    var private1 = 42
+
+    @field:PrivateApi
+    var private2 = 15
+
+    @PrivateApi
+    fun privateFun() = Unit
+
+    @PublicApi
+    @PrivateApi
+    fun privateFun2() = Unit
+
+    fun otherFun() = Unit
+}
+
+// Member annotations should be ignored in explicitly private classes
+@PrivateApi
+class MarkedPrivateWithPublicMembers {
+    @PublicApi
+    var public1 = 42
+
+    @field:PublicApi
+    var public2 = 15
+
+    @PublicApi
+    fun publicFun() = Unit
+
+    fun otherFun() = Unit
+}
+
+@PrivateApi
+@PublicApi
+class PublicAndPrivateFilteredOut

--- a/src/functionalTest/resources/examples/gradle/configuration/publicMarkers/markers.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/publicMarkers/markers.gradle.kts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    publicMarkers.add("foo.PublicClass")
+    publicMarkers.add("foo.PublicField")
+    publicMarkers.add("foo.PublicProperty")
+
+    publicPackages.add("foo.api")
+    publicClasses.add("foo.PublicClass")
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/publicMarkers/mixedMarkers.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/publicMarkers/mixedMarkers.gradle.kts
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    nonPublicMarkers.add("mixed.PrivateApi")
+    publicMarkers.add("mixed.PublicApi")
+}

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -34,4 +34,28 @@ open class ApiValidationExtension {
      * Example of such a class could be `com.package.android.BuildConfig`.
      */
     public var ignoredClasses: MutableSet<String> = HashSet()
+
+    /**
+     * Fully qualified names of annotations that can be used to explicitly mark public declarations. 
+     * If at least one of [publicMarkers], [publicPackages] or [publicClasses] is defined,
+     * all declarations not covered by any of them will be considered non-public. 
+     * [ignoredPackages], [ignoredClasses] and [nonPublicMarkers] can be used for additional filtering.
+     */
+    public var publicMarkers: MutableSet<String> = HashSet()
+
+    /**
+     * Fully qualified package names that contain public declarations. 
+     * If at least one of [publicMarkers], [publicPackages] or [publicClasses] is defined,
+     * all declarations not covered by any of them will be considered non-public. 
+     * [ignoredPackages], [ignoredClasses] and [nonPublicMarkers] can be used for additional filtering.
+     */
+    public var publicPackages: MutableSet<String> = HashSet()
+
+    /**
+     * Fully qualified names of public classes.
+     * If at least one of [publicMarkers], [publicPackages] or [publicClasses] is defined,
+     * all declarations not covered by any of them will be considered non-public.
+     * [ignoredPackages], [ignoredClasses] and [nonPublicMarkers] can be used for additional filtering.
+     */
+    public var publicClasses: MutableSet<String> = HashSet()
 }

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -58,4 +58,10 @@ open class ApiValidationExtension {
      * [ignoredPackages], [ignoredClasses] and [nonPublicMarkers] can be used for additional filtering.
      */
     public var publicClasses: MutableSet<String> = HashSet()
+
+    /**
+     * Non-default Gradle SourceSet names that should be validated.
+     * By default, only the `main` source set is checked.
+     */
+    public var additionalSourceSets: MutableSet<String> = HashSet()
 }

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -53,6 +53,24 @@ open class KotlinApiBuildTask @Inject constructor(
         get() = _ignoredClasses ?: extension?.ignoredClasses ?: emptySet()
         set(value) { _ignoredClasses = value }
 
+    private var _publicPackages: Set<String>? = null
+    @get:Input
+    var publicPackages: Set<String>
+        get() = _publicPackages ?: extension?.publicPackages ?: emptySet()
+        set(value) { _publicPackages = value }
+
+    private var _publicMarkers: Set<String>? = null
+    @get:Input
+    var publicMarkers: Set<String>
+        get() = _publicMarkers ?: extension?.publicMarkers ?: emptySet()
+        set(value) { _publicMarkers = value}
+
+    private var _publicClasses: Set<String>? = null
+    @get:Input
+    var publicClasses: Set<String>
+        get() = _publicClasses ?: extension?.publicClasses ?: emptySet()
+        set(value) { _publicClasses = value }
+
     @get:Internal
     internal val projectName = project.name
 
@@ -79,8 +97,9 @@ open class KotlinApiBuildTask @Inject constructor(
 
 
         val filteredSignatures = signatures
+            .retainExplicitlyIncludedIfDeclared(publicPackages, publicClasses, publicMarkers)
             .filterOutNonPublic(ignoredPackages, ignoredClasses)
-            .filterOutAnnotated(nonPublicMarkers.map { it.replace(".", "/") }.toSet())
+            .filterOutAnnotated(nonPublicMarkers.map(::replaceDots).toSet())
 
         outputApiDir.resolve("$projectName.api").bufferedWriter().use { writer ->
             filteredSignatures


### PR DESCRIPTION
The pull request introduces support for two new features:

-  Explicit public markers. Existing properties `ignoredProjects`, `ignoredPackages` and `nonPublicMarkers` allow excluding some parts of API from compatibility validation and checking the rest. New `publicMarkers`, `publicPackages` and `publicClasses` do the opposite: if any of them is used, only explicitly marked declarations are considered for validation, all the rest are excluded.
- Adding extra Gradle source sets to check for Kotlin-JVM project. Without this change only the `main` source set can be validated.

### Motivation

In `kotlin.git` we would like to maintain binary compatibility only for a few parts of the `:kotlin-gradle-plugin` project related to the External Kotlin Target API, that will be used by third parties when implemented. The declarations are either annotated, or belong to a specific package. Use of the existing API of validator to exclude everything else is not very convenient and would complicate maintenance of the project in the future. Because, for instance, adding new packages would require build script changes, as they have to be excluded from validation. Parts of the relevant code belong to a custom Gradle source set, so without the second introduced feature validation is not possible.

### Implementation notes

- Explicit marker mode only affects validation if any of the new `public*` properties are used in a build script, which shouldn't affect any users that don't touch the properties
- Explicit declaration filtering happens before the usual filtering of ignored projects, packages and marked non-public declarations. This makes it possible to combine two modes, e.g. filter out marked non-public members of a class from a public package
- In case of clashes, when the same declaration is both ignored and explicitly public at the same time, ignored "wins"
- Listing extra source sets for validation is only supported for projects with the `kotlin-jvm` Gradle plugin to minimize the changes