### PR TITLE
Update kotlinx-metadata-jvm to 0.6.0 and Kotlin to 1.8.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,11 +74,11 @@ configurations.implementation {
 
 dependencies {
     implementation(gradleApi())
-    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.6.0")
     implementation("org.ow2.asm:asm:9.2")
     implementation("org.ow2.asm:asm-tree:9.2")
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
-    compileOnly("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.6.0")
+    compileOnly("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.8.10")
 //    compileOnly("com.android.tools.build:gradle:${androidGradlePluginVersion}")
 
     // The test needs the full kotlin multiplatform plugin loaded as it has no visibility of previously loaded plugins,
@@ -96,15 +96,15 @@ dependencies {
 
 tasks.compileKotlin {
     kotlinOptions.apply {
+        allWarningsAsErrors = true
+
         languageVersion = "1.4"
         apiVersion = "1.4"
         jvmTarget = "1.8"
-        // TODO revert that when updating Kotlin. This flag also affects kts files and prevents
-        // the project from build due to "w: Language version 1.4 is deprecated and its support will be removed"
-//        allWarningsAsErrors = true
-        // Suppress the warning about kotlin-reflect 1.3 and kotlin-stdlib 1.4 in the classpath.
-        // It's incorrect in this case because we're limiting API version to 1.3 anyway.
-        freeCompilerArgs += "-Xskip-runtime-version-check"
+
+        // Suppressing "w: Language version 1.4 is deprecated and its support will be removed" message
+        // because LV=1.4 in practice is mandatory as it is a default language version in Gradle 7.0+ for users' kts scripts.
+        freeCompilerArgs += "-Xsuppress-version-warnings"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=0.12.1-SNAPSHOT
 group=org.jetbrains.kotlinx
 
-kotlinVersion=1.6.0
+kotlinVersion=1.8.10
 pluginPublishVersion=0.10.1
 
 kotlin.stdlib.default.dependency=false

--- a/src/main/kotlin/api/KotlinMetadataVisibilities.kt
+++ b/src/main/kotlin/api/KotlinMetadataVisibilities.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o.
+ * Copyright 2016-2023 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
@@ -7,7 +7,7 @@ package kotlinx.validation.api
 
 import kotlinx.metadata.*
 import kotlinx.metadata.jvm.*
-import kotlinx.metadata.jvm.KotlinClassHeader.Companion.COMPATIBLE_METADATA_VERSION
+import kotlinx.metadata.jvm.KotlinClassMetadata.Companion.COMPATIBLE_METADATA_VERSION
 import org.objectweb.asm.tree.*
 
 class ClassVisibility(
@@ -58,7 +58,7 @@ val ClassNode.kotlinMetadata: KotlinClassMetadata?
         val metadata = findAnnotation("kotlin/Metadata", false) ?: return null
         @Suppress("UNCHECKED_CAST")
         val header = with(metadata) {
-            KotlinClassHeader(
+            Metadata(
                 kind = get("k") as Int?,
                 metadataVersion = (get("mv") as List<Int>?)?.toIntArray(),
                 data1 = (get("d1") as List<String>?)?.toTypedArray(),

--- a/src/test/kotlin/tests/utils.kt
+++ b/src/test/kotlin/tests/utils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o.
+ * Copyright 2016-2023 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
@@ -39,7 +39,3 @@ private fun CharSequence.trimTrailingWhitespacesAndAddNewlineAtEOF(): String =
         this.lineSequence().map { it.trimEnd() }.joinToString(separator = "\n").let {
             if (it.endsWith("\n")) it else it + "\n"
         }
-
-
-private val UPPER_CASE_CHARS = Regex("[A-Z]+")
-fun String.replaceCamelCaseWithDashedLowerCase() = replace(UPPER_CASE_CHARS) { "-" + it.value.toLowerCase() }


### PR DESCRIPTION
Remove -Xskip-runtime-version-check flag as it is deprecated and has no effect.

Add -Xsuppress-version-warnings flag to suppress "LV 1.4 is deprecated" warning and enable allWarningsAsErrors back.

Remove unused declarations that contained deprecated code (.lowercase()).