### PR TITLE
Support to exclude classes / packages by Regex pattern

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/test/IgnoredTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/IgnoredTests.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.test
+
+import kotlinx.validation.api.*
+import kotlinx.validation.api.BaseKotlinGradleTest
+import kotlinx.validation.api.assertTaskSuccess
+import kotlinx.validation.api.buildGradleKts
+import kotlinx.validation.api.kotlin
+import kotlinx.validation.api.readFileList
+import kotlinx.validation.api.resolve
+import kotlinx.validation.api.runner
+import kotlinx.validation.api.test
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import kotlin.test.assertTrue
+
+internal class IgnoredTests : BaseKotlinGradleTest() {
+
+    @Test
+    fun `apiCheck should succeed, when given class is not in api-File, but is ignored via ignored pattern`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/ignored/oneValidPattern.gradle.kts")
+            }
+
+            kotlin("BuildConfig.kt") {
+                resolve("examples/classes/BuildConfig.kt")
+            }
+
+            emptyApiFile(projectName = rootProjectDir.name)
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+
+    @Test
+    fun `apiCheck should succeed, when given class is not in api-File, but is ignored via ignored pattern (based on package)`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/ignored/oneValidPackagePattern.gradle.kts")
+            }
+
+            kotlin("BuildConfig.kt") {
+                resolve("examples/classes/BuildConfig.kt")
+            }
+
+            emptyApiFile(projectName = rootProjectDir.name)
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+
+    @Test
+    fun `apiDump should not dump ignored classes, when class is excluded via ignored pattern`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/ignored/oneValidPatternPackageClass.gradle.kts")
+            }
+            kotlin("BuildConfig.kt") {
+                resolve("examples/classes/BuildConfig.kt")
+            }
+            kotlin("AnotherBuildConfig.kt") {
+                resolve("examples/classes/AnotherBuildConfig.kt")
+            }
+
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            assertTrue(rootProjectApiDump.exists(), "api dump file should exist")
+
+            val expected = readFileList("examples/classes/AnotherBuildConfig.dump")
+            Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
+        }
+    }
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/ignored/oneValidPackagePattern.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/ignored/oneValidPackagePattern.gradle.kts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    ignored.add("com\\/company\\/.+")
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/ignored/oneValidPattern.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/ignored/oneValidPattern.gradle.kts
@@ -1,0 +1,3 @@
+configure<kotlinx.validation.ApiValidationExtension> {
+    ignored.add(".+\\/BuildConfig")
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/ignored/oneValidPatternPackageClass.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/ignored/oneValidPatternPackageClass.gradle.kts
@@ -1,0 +1,3 @@
+configure<kotlinx.validation.ApiValidationExtension> {
+    ignored.add(".+\\/company\\/BuildConfig")
+}

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -34,4 +34,12 @@ open class ApiValidationExtension {
      * Example of such a class could be `com.package.android.BuildConfig`.
      */
     public var ignoredClasses: MutableSet<String> = HashSet()
+
+    /**
+     * Defines a regex pattern used to define classes and packages that are ignored by the API check.
+     *
+     * Example of such a package could be `.+\/internal\/.+`.
+     * An example of such a class could be `.+\/BuildConfig`
+     */
+    public var ignored: MutableSet<String> = HashSet()
 }

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -11,6 +11,7 @@ import org.gradle.api.file.*
 import org.gradle.api.tasks.*
 import java.io.*
 import java.util.jar.JarFile
+import java.util.regex.Pattern
 import javax.inject.Inject
 
 open class KotlinApiBuildTask @Inject constructor(
@@ -53,6 +54,12 @@ open class KotlinApiBuildTask @Inject constructor(
         get() = _ignoredClasses ?: extension?.ignoredClasses ?: emptySet()
         set(value) { _ignoredClasses = value }
 
+    private var _ignored: Set<Pattern>? = null
+    @get:Input
+    var ignored : Set<Pattern>
+        get() = _ignored ?: extension?.ignored?.map { Pattern.compile(it) }?.toSet() ?: emptySet()
+        set(value) { _ignored = value }
+
     @get:Internal
     internal val projectName = project.name
 
@@ -79,7 +86,7 @@ open class KotlinApiBuildTask @Inject constructor(
 
 
         val filteredSignatures = signatures
-            .filterOutNonPublic(ignoredPackages, ignoredClasses)
+            .filterOutNonPublic(ignored, ignoredPackages, ignoredClasses)
             .filterOutAnnotated(nonPublicMarkers.map { it.replace(".", "/") }.toSet())
 
         outputApiDir.resolve("$projectName.api").bufferedWriter().use { writer ->

--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -5,13 +5,20 @@
 
 package kotlinx.validation.api
 
-import kotlinx.metadata.jvm.*
-import kotlinx.validation.*
-import org.objectweb.asm.*
-import org.objectweb.asm.tree.*
-import java.io.*
+import kotlinx.metadata.jvm.JvmFieldSignature
+import kotlinx.metadata.jvm.JvmMethodSignature
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.validation.ExternalApi
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.AnnotationNode
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.FieldNode
+import org.objectweb.asm.tree.MethodNode
+import java.io.InputStream
 import java.util.*
-import java.util.jar.*
+import java.util.jar.JarFile
+import java.util.regex.Pattern
 
 @ExternalApi
 @Suppress("unused")
@@ -148,6 +155,7 @@ public fun List<ClassBinarySignature>.filterOutAnnotated(targetAnnotations: Set<
 
 @ExternalApi
 public fun List<ClassBinarySignature>.filterOutNonPublic(
+    nonPublic: Collection<Pattern> = emptyList(),
     nonPublicPackages: Collection<String> = emptyList(),
     nonPublicClasses: Collection<String> = emptyList()
 ): List<ClassBinarySignature> {
@@ -156,6 +164,8 @@ public fun List<ClassBinarySignature>.filterOutNonPublic(
     val excludedClasses = nonPublicClasses.map(pathMapper)
 
     val classByName = associateBy { it.name }
+
+    fun ClassBinarySignature.isNonPublic() = nonPublic.any { it.matcher(name).matches() }
 
     fun ClassBinarySignature.isInNonPublicPackage() =
         nonPublicPackagePaths.any { name.startsWith(it) }
@@ -189,7 +199,8 @@ public fun List<ClassBinarySignature>.filterOutNonPublic(
         )
     }
 
-    return filter { !it.isInNonPublicPackage() && !it.isInExcludedClasses() && it.isPublicAndAccessible() }
+
+    return filter { !it.isInNonPublicPackage() && !it.isInExcludedClasses() && !it.isNonPublic() && it.isPublicAndAccessible() }
         .map { it.flattenNonPublicBases() }
         .filterNot { it.isNotUsedWhenEmpty && it.memberSignatures.isEmpty() }
 }


### PR DESCRIPTION
The pull request introduced a new configuration option `ignored`. 

`ignored` takes an array of regex patterns to exclude whole packages and classes based on this pattern. This configuration can be provided alongside the already existing `ignoredPackages` and `ignoredClasses` and offers much greater flexibility on ignoring sources from being included in the validation. 

## Motivation

The current offered APIs require absolute package names and class names, making very verbose for large projects. 
Additionally the `nonPublicMarkers` would be great for these situations, but we can not attach them to generated sources from plugins, which we have no control over. 

Using the `regex` provides much higher flexibility and it is possible to for example exclude all packages including `/internal/` in their package name. 

Or similar all generated classes by Androids navigation plugin which end in `com.company.MyFragmentDirections`