### PR TITLE
Test util: Annotate file paths with `@Language("file-reference")`

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
@@ -7,6 +7,7 @@ package kotlinx.validation.api
 
 import kotlinx.validation.API_DIR
 import org.gradle.testkit.runner.*
+import org.intellij.lang.annotations.Language
 import java.io.*
 
 internal fun BaseKotlinGradleTest.test(fn: BaseKotlinScope.() -> Unit): GradleRunner {
@@ -38,7 +39,7 @@ internal fun BaseKotlinGradleTest.test(fn: BaseKotlinScope.() -> Unit): GradleRu
 /**
  * same as [file][FileContainer.file], but prepends "src/${sourceSet}/kotlin" before given `classFileName`
  */
-internal fun FileContainer.kotlin(classFileName: String, sourceSet:String = "main", fn: AppendableScope.() -> Unit) {
+internal fun FileContainer.kotlin(classFileName: String, sourceSet: String = "main", fn: AppendableScope.() -> Unit) {
     require(classFileName.endsWith(".kt")) {
         "ClassFileName must end with '.kt'"
     }
@@ -50,7 +51,7 @@ internal fun FileContainer.kotlin(classFileName: String, sourceSet:String = "mai
 /**
  * same as [file][FileContainer.file], but prepends "src/${sourceSet}/java" before given `classFileName`
  */
-internal fun FileContainer.java(classFileName: String, sourceSet:String = "main", fn: AppendableScope.() -> Unit) {
+internal fun FileContainer.java(classFileName: String, sourceSet: String = "main", fn: AppendableScope.() -> Unit) {
     require(classFileName.endsWith(".java")) {
         "ClassFileName must end with '.java'"
     }
@@ -110,7 +111,7 @@ internal fun BaseKotlinScope.runner(fn: Runner.() -> Unit) {
     this.runner = runner
 }
 
-internal fun AppendableScope.resolve(fileName: String) {
+internal fun AppendableScope.resolve(@Language("file-reference") fileName: String) {
     this.files.add(fileName)
 }
 
@@ -132,7 +133,7 @@ internal class BaseKotlinScope : FileContainer {
 internal class DirectoryScope(
     val dirPath: String,
     val parent: FileContainer
-): FileContainer {
+) : FileContainer {
 
     override fun file(fileName: String, fn: AppendableScope.() -> Unit) {
         parent.file("$dirPath/$fileName", fn)
@@ -147,8 +148,8 @@ internal class Runner {
     val arguments: MutableList<String> = mutableListOf("--configuration-cache")
 }
 
-internal fun readFileList(fileName: String): String {
-    val resource = BaseKotlinGradleTest::class.java.classLoader.getResource(fileName)
+internal fun readFileList(@Language("file-reference") fileName: String): String {
+    val resource = BaseKotlinGradleTest::class.java.getResource(fileName)
         ?: throw IllegalStateException("Could not find resource '$fileName'")
     return File(resource.toURI()).readText()
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/AndroidLibraryTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/AndroidLibraryTest.kt
@@ -86,33 +86,33 @@ internal class AndroidLibraryTest : BaseKotlinGradleTest() {
      */
     private fun BaseKotlinScope.createProjectWithSubModules() {
         settingsGradleKts {
-            resolve("examples/gradle/settings/settings-android-project.gradle.kts")
+            resolve("/examples/gradle/settings/settings-android-project.gradle.kts")
         }
         buildGradleKts {
-            resolve("examples/gradle/base/androidProjectRoot.gradle.kts")
+            resolve("/examples/gradle/base/androidProjectRoot.gradle.kts")
         }
         initLocalProperties()
 
         dir("kotlin-library") {
             buildGradleKts {
-                resolve("examples/gradle/base/androidKotlinLibrary.gradle.kts")
+                resolve("/examples/gradle/base/androidKotlinLibrary.gradle.kts")
             }
             kotlin("KotlinLib.kt") {
-                resolve("examples/classes/KotlinLib.kt")
+                resolve("/examples/classes/KotlinLib.kt")
             }
             apiFile(projectName = "kotlin-library") {
-                resolve("examples/classes/KotlinLib.dump")
+                resolve("/examples/classes/KotlinLib.dump")
             }
         }
         dir("java-library") {
             buildGradleKts {
-                resolve("examples/gradle/base/androidJavaLibrary.gradle.kts")
+                resolve("/examples/gradle/base/androidJavaLibrary.gradle.kts")
             }
             java("JavaLib.java") {
-                resolve("examples/classes/JavaLib.java")
+                resolve("/examples/classes/JavaLib.java")
             }
             apiFile(projectName = "java-library") {
-                resolve("examples/classes/JavaLib.dump")
+                resolve("/examples/classes/JavaLib.dump")
             }
         }
     }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/DefaultConfigTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/DefaultConfigTests.kt
@@ -16,7 +16,7 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
     fun `apiCheck should fail, when there is no api directory, even if there are no Kotlin sources`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
             }
             runner {
                 arguments.add(":apiCheck")
@@ -33,7 +33,7 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
     fun `check should fail, when there is no api directory, even if there are no Kotlin sources`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
             }
 
             runner {
@@ -51,7 +51,7 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
     fun `apiCheck should succeed, when api-File is empty, but no kotlin files are included in SourceSet`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
             }
 
             emptyApiFile(projectName = rootProjectDir.name)
@@ -70,13 +70,13 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
     fun `apiCheck should succeed when public classes match api file`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
             }
             kotlin("AnotherBuildConfig.kt") {
-                resolve("examples/classes/AnotherBuildConfig.kt")
+                resolve("/examples/classes/AnotherBuildConfig.kt")
             }
             apiFile(projectName = rootProjectDir.name) {
-                resolve("examples/classes/AnotherBuildConfig.dump")
+                resolve("/examples/classes/AnotherBuildConfig.dump")
             }
 
             runner {
@@ -93,13 +93,13 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
     fun `apiCheck should succeed when public classes match api file ignoring case`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
             }
             kotlin("AnotherBuildConfig.kt") {
-                resolve("examples/classes/AnotherBuildConfig.kt")
+                resolve("/examples/classes/AnotherBuildConfig.kt")
             }
             apiFile(projectName = rootProjectDir.name.uppercase()) {
-                resolve("examples/classes/AnotherBuildConfig.dump")
+                resolve("/examples/classes/AnotherBuildConfig.dump")
             }
 
             runner {
@@ -116,11 +116,11 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
     fun `apiCheck should fail, when a public class is not in api-File`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
             }
 
             kotlin("BuildConfig.kt") {
-                resolve("examples/classes/BuildConfig.kt")
+                resolve("/examples/classes/BuildConfig.kt")
             }
 
             emptyApiFile(projectName = rootProjectDir.name)
@@ -148,7 +148,7 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
     fun `apiDump should create empty api file when there are no Kotlin sources`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
             }
 
             runner {
@@ -169,10 +169,10 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
     fun `apiDump should create api file with the name of the project, respecting settings file`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
             }
             settingsGradleKts {
-                resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+                resolve("/examples/gradle/settings/settings-name-testproject.gradle.kts")
             }
 
             runner {
@@ -197,10 +197,10 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
     fun `apiDump should dump public classes`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
             }
             kotlin("AnotherBuildConfig.kt") {
-                resolve("examples/classes/AnotherBuildConfig.kt")
+                resolve("/examples/classes/AnotherBuildConfig.kt")
             }
 
             runner {
@@ -213,7 +213,7 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
 
             assertTrue(rootProjectApiDump.exists(), "api dump file should exist")
 
-            val expected = readFileList("examples/classes/AnotherBuildConfig.dump")
+            val expected = readFileList("/examples/classes/AnotherBuildConfig.dump")
             Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
         }
     }
@@ -222,7 +222,7 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
     fun `apiCheck should be run when we run check`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
             }
 
             emptyApiFile(projectName = rootProjectDir.name)

--- a/src/functionalTest/kotlin/kotlinx/validation/test/IgnoredClassesTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/IgnoredClassesTests.kt
@@ -24,12 +24,12 @@ internal class IgnoredClassesTests : BaseKotlinGradleTest() {
     fun `apiCheck should succeed, when given class is not in api-File, but is ignored via ignoredClasses`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
-                resolve("examples/gradle/configuration/ignoredClasses/oneValidFullyQualifiedClass.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/ignoredClasses/oneValidFullyQualifiedClass.gradle.kts")
             }
 
             kotlin("BuildConfig.kt") {
-                resolve("examples/classes/BuildConfig.kt")
+                resolve("/examples/classes/BuildConfig.kt")
             }
 
             emptyApiFile(projectName = rootProjectDir.name)
@@ -48,12 +48,12 @@ internal class IgnoredClassesTests : BaseKotlinGradleTest() {
     fun `apiCheck should succeed, when given class is not in api-File, but is ignored via ignoredPackages`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
-                resolve("examples/gradle/configuration/ignoredPackages/oneValidPackage.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/ignoredPackages/oneValidPackage.gradle.kts")
             }
 
             kotlin("BuildConfig.kt") {
-                resolve("examples/classes/BuildConfig.kt")
+                resolve("/examples/classes/BuildConfig.kt")
             }
 
             emptyApiFile(projectName = rootProjectDir.name)
@@ -72,14 +72,14 @@ internal class IgnoredClassesTests : BaseKotlinGradleTest() {
     fun `apiDump should not dump ignoredClasses, when class is excluded via ignoredClasses`() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
-                resolve("examples/gradle/configuration/ignoredClasses/oneValidFullyQualifiedClass.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/ignoredClasses/oneValidFullyQualifiedClass.gradle.kts")
             }
             kotlin("BuildConfig.kt") {
-                resolve("examples/classes/BuildConfig.kt")
+                resolve("/examples/classes/BuildConfig.kt")
             }
             kotlin("AnotherBuildConfig.kt") {
-                resolve("examples/classes/AnotherBuildConfig.kt")
+                resolve("/examples/classes/AnotherBuildConfig.kt")
             }
 
             runner {
@@ -92,7 +92,7 @@ internal class IgnoredClassesTests : BaseKotlinGradleTest() {
 
             assertTrue(rootProjectApiDump.exists(), "api dump file should exist")
 
-            val expected = readFileList("examples/classes/AnotherBuildConfig.dump")
+            val expected = readFileList("/examples/classes/AnotherBuildConfig.dump")
             Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
         }
     }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/InputJarTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/InputJarTest.kt
@@ -14,16 +14,16 @@ class InputJarTest : BaseKotlinGradleTest() {
     fun testOverrideInputJar() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
-                resolve("examples/gradle/configuration/jarAsInput/inputJar.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/jarAsInput/inputJar.gradle.kts")
             }
 
             kotlin("Properties.kt") {
-                resolve("examples/classes/Properties.kt")
+                resolve("/examples/classes/Properties.kt")
             }
 
             apiFile(projectName = rootProjectDir.name) {
-                resolve("examples/classes/PropertiesJarTransformed.dump")
+                resolve("/examples/classes/PropertiesJarTransformed.dump")
             }
 
             runner {

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultiPlatformSingleJvmTargetTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultiPlatformSingleJvmTargetTest.kt
@@ -13,10 +13,10 @@ import java.io.File
 internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
     private fun BaseKotlinScope.createProjectHierarchyWithPluginOnRoot() {
         settingsGradleKts {
-            resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+            resolve("/examples/gradle/settings/settings-name-testproject.gradle.kts")
         }
         buildGradleKts {
-            resolve("examples/gradle/base/multiplatformWithSingleJvmTarget.gradle.kts")
+            resolve("/examples/gradle/base/multiplatformWithSingleJvmTarget.gradle.kts")
         }
     }
 
@@ -31,17 +31,17 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
 
                 dir("api/") {
                     file("testproject.api") {
-                        resolve("examples/classes/Subsub1Class.dump")
-                        resolve("examples/classes/Subsub2Class.dump")
+                        resolve("/examples/classes/Subsub1Class.dump")
+                        resolve("/examples/classes/Subsub2Class.dump")
                     }
                 }
 
                 dir("src/jvmMain/kotlin") {}
                 kotlin("Subsub1Class.kt", "commonMain") {
-                    resolve("examples/classes/Subsub1Class.kt")
+                    resolve("/examples/classes/Subsub1Class.kt")
                 }
                 kotlin("Subsub2Class.kt", "jvmMain") {
-                    resolve("examples/classes/Subsub2Class.kt")
+                    resolve("/examples/classes/Subsub2Class.kt")
                 }
 
             }
@@ -63,17 +63,17 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
 
                 dir("api/") {
                     file("testproject.api") {
-                        resolve("examples/classes/Subsub2Class.dump")
-                        resolve("examples/classes/Subsub1Class.dump")
+                        resolve("/examples/classes/Subsub2Class.dump")
+                        resolve("/examples/classes/Subsub1Class.dump")
                     }
                 }
 
                 dir("src/jvmMain/kotlin") {}
                 kotlin("Subsub1Class.kt", "commonMain") {
-                    resolve("examples/classes/Subsub1Class.kt")
+                    resolve("/examples/classes/Subsub1Class.kt")
                 }
                 kotlin("Subsub2Class.kt", "jvmMain") {
-                    resolve("examples/classes/Subsub2Class.kt")
+                    resolve("/examples/classes/Subsub2Class.kt")
                 }
 
             }
@@ -98,10 +98,10 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
 
                 dir("src/jvmMain/kotlin") {}
                 kotlin("Subsub1Class.kt", "commonMain") {
-                    resolve("examples/classes/Subsub1Class.kt")
+                    resolve("/examples/classes/Subsub1Class.kt")
                 }
                 kotlin("Subsub2Class.kt", "jvmMain") {
-                    resolve("examples/classes/Subsub2Class.kt")
+                    resolve("/examples/classes/Subsub2Class.kt")
                 }
 
             }
@@ -109,9 +109,9 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
         runner.build().apply {
             assertTaskSuccess(":apiDump")
 
-            val commonExpectedApi = readFileList("examples/classes/Subsub1Class.dump")
+            val commonExpectedApi = readFileList("/examples/classes/Subsub1Class.dump")
 
-            val mainExpectedApi = commonExpectedApi + "\n" + readFileList("examples/classes/Subsub2Class.dump")
+            val mainExpectedApi = commonExpectedApi + "\n" + readFileList("/examples/classes/Subsub2Class.dump")
             assertThat(jvmApiDump.readText()).isEqualToIgnoringNewLines(mainExpectedApi)
         }
     }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
@@ -15,10 +15,10 @@ import java.io.InputStreamReader
 internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
     private fun BaseKotlinScope.createProjectHierarchyWithPluginOnRoot() {
         settingsGradleKts {
-            resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+            resolve("/examples/gradle/settings/settings-name-testproject.gradle.kts")
         }
         buildGradleKts {
-            resolve("examples/gradle/base/multiplatformWithJvmTargets.gradle.kts")
+            resolve("/examples/gradle/base/multiplatformWithJvmTargets.gradle.kts")
         }
     }
 
@@ -32,23 +32,23 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
 
             dir("api/jvm/") {
                 file("testproject.api") {
-                    resolve("examples/classes/Subsub1Class.dump")
-                    resolve("examples/classes/Subsub2Class.dump")
+                    resolve("/examples/classes/Subsub1Class.dump")
+                    resolve("/examples/classes/Subsub2Class.dump")
                 }
             }
 
             dir("api/anotherJvm/") {
                 file("testproject.api") {
-                    resolve("examples/classes/Subsub1Class.dump")
+                    resolve("/examples/classes/Subsub1Class.dump")
                 }
             }
 
             dir("src/jvmMain/kotlin") {}
             kotlin("Subsub1Class.kt", "commonMain") {
-                resolve("examples/classes/Subsub1Class.kt")
+                resolve("/examples/classes/Subsub1Class.kt")
             }
             kotlin("Subsub2Class.kt", "jvmMain") {
-                resolve("examples/classes/Subsub2Class.kt")
+                resolve("/examples/classes/Subsub2Class.kt")
             }
 
         }
@@ -71,23 +71,23 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
 
             dir("api/jvm/") {
                 file("testproject.api") {
-                    resolve("examples/classes/Subsub2Class.dump")
-                    resolve("examples/classes/Subsub1Class.dump")
+                    resolve("/examples/classes/Subsub2Class.dump")
+                    resolve("/examples/classes/Subsub1Class.dump")
                 }
             }
 
             dir("api/anotherJvm/") {
                 file("testproject.api") {
-                    resolve("examples/classes/Subsub2Class.dump")
+                    resolve("/examples/classes/Subsub2Class.dump")
                 }
             }
 
             dir("src/jvmMain/kotlin") {}
             kotlin("Subsub1Class.kt", "commonMain") {
-                resolve("examples/classes/Subsub1Class.kt")
+                resolve("/examples/classes/Subsub1Class.kt")
             }
             kotlin("Subsub2Class.kt", "jvmMain") {
-                resolve("examples/classes/Subsub2Class.kt")
+                resolve("/examples/classes/Subsub2Class.kt")
             }
 
         }
@@ -112,10 +112,10 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
 
             dir("src/jvmMain/kotlin") {}
             kotlin("Subsub1Class.kt", "commonMain") {
-                resolve("examples/classes/Subsub1Class.kt")
+                resolve("/examples/classes/Subsub1Class.kt")
             }
             kotlin("Subsub2Class.kt", "jvmMain") {
-                resolve("examples/classes/Subsub2Class.kt")
+                resolve("/examples/classes/Subsub2Class.kt")
             }
 
         }
@@ -126,10 +126,10 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
 
             System.err.println(output)
 
-            val anotherExpectedApi = readFileList("examples/classes/Subsub1Class.dump")
+            val anotherExpectedApi = readFileList("/examples/classes/Subsub1Class.dump")
             assertThat(anotherApiDump.readText()).isEqualToIgnoringNewLines(anotherExpectedApi)
 
-            val mainExpectedApi = anotherExpectedApi + "\n" + readFileList("examples/classes/Subsub2Class.dump")
+            val mainExpectedApi = anotherExpectedApi + "\n" + readFileList("/examples/classes/Subsub2Class.dump")
             assertThat(jvmApiDump.readText()).isEqualToIgnoringNewLines(mainExpectedApi)
         }
     }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/NonPublicMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/NonPublicMarkersTest.kt
@@ -14,16 +14,16 @@ class NonPublicMarkersTest : BaseKotlinGradleTest() {
     fun testIgnoredMarkersOnProperties() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
-                resolve("examples/gradle/configuration/nonPublicMarkers/markers.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/nonPublicMarkers/markers.gradle.kts")
             }
 
             kotlin("Properties.kt") {
-                resolve("examples/classes/Properties.kt")
+                resolve("/examples/classes/Properties.kt")
             }
 
             apiFile(projectName = rootProjectDir.name) {
-                resolve("examples/classes/Properties.dump")
+                resolve("/examples/classes/Properties.dump")
             }
 
             runner {

--- a/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnRootTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnRootTests.kt
@@ -32,29 +32,29 @@ internal class SubprojectsWithPluginOnRootTests : BaseKotlinGradleTest() {
      */
     private fun BaseKotlinScope.createProjectHierarchyWithPluginOnRoot() {
         settingsGradleKts {
-            resolve("examples/gradle/settings/settings-with-hierarchy.gradle.kts")
+            resolve("/examples/gradle/settings/settings-with-hierarchy.gradle.kts")
         }
         buildGradleKts {
-            resolve("examples/gradle/base/withPlugin.gradle.kts")
+            resolve("/examples/gradle/base/withPlugin.gradle.kts")
         }
         dir("sub1") {
             buildGradleKts {
-                resolve("examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
+                resolve("/examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
             }
             dir("subsub1") {
                 buildGradleKts {
-                    resolve("examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
+                    resolve("/examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
                 }
             }
             dir("subsub2") {
                 buildGradleKts {
-                    resolve("examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
+                    resolve("/examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
                 }
             }
         }
         dir("sub2") {
             buildGradleKts {
-                resolve("examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
+                resolve("/examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
             }
         }
     }
@@ -181,10 +181,10 @@ internal class SubprojectsWithPluginOnRootTests : BaseKotlinGradleTest() {
             dir("sub1") {
                 dir("subsub2") {
                     kotlin("Subsub2Class.kt") {
-                        resolve("examples/classes/Subsub2Class.kt")
+                        resolve("/examples/classes/Subsub2Class.kt")
                     }
                     apiFile(projectName = "subsub2") {
-                        resolve("examples/classes/Subsub2Class.dump")
+                        resolve("/examples/classes/Subsub2Class.dump")
                     }
                 }
             }
@@ -211,18 +211,18 @@ internal class SubprojectsWithPluginOnRootTests : BaseKotlinGradleTest() {
 
                 dir("subsub1") {
                     kotlin("Subsub1Class.kt") {
-                        resolve("examples/classes/Subsub1Class.kt")
+                        resolve("/examples/classes/Subsub1Class.kt")
                     }
                     apiFile(projectName = "subsub1") {
-                        resolve("examples/classes/Subsub1Class.dump")
+                        resolve("/examples/classes/Subsub1Class.dump")
                     }
                 }
                 dir("subsub2") {
                     kotlin("Subsub2Class.kt") {
-                        resolve("examples/classes/Subsub2Class.kt")
+                        resolve("/examples/classes/Subsub2Class.kt")
                     }
                     apiFile(projectName = "subsub2") {
-                        resolve("examples/classes/Subsub2Class.dump")
+                        resolve("/examples/classes/Subsub2Class.dump")
                     }
                 }
             }
@@ -273,12 +273,12 @@ internal class SubprojectsWithPluginOnRootTests : BaseKotlinGradleTest() {
             dir("sub1") {
                 dir("subsub1") {
                     kotlin("Subsub1Class.kt") {
-                        resolve("examples/classes/Subsub1Class.kt")
+                        resolve("/examples/classes/Subsub1Class.kt")
                     }
                 }
                 dir("subsub2") {
                     kotlin("Subsub2Class.kt") {
-                        resolve("examples/classes/Subsub2Class.kt")
+                        resolve("/examples/classes/Subsub2Class.kt")
                     }
                 }
             }
@@ -304,12 +304,12 @@ internal class SubprojectsWithPluginOnRootTests : BaseKotlinGradleTest() {
 
             val apiSubsub1 = rootProjectDir.resolve("sub1/subsub1/api/subsub1.api")
             assertTrue(apiSubsub1.exists(), "api dump file ${apiSubsub1.path} should exist")
-            val apiSubsub1Expected = readFileList("examples/classes/Subsub1Class.dump")
+            val apiSubsub1Expected = readFileList("/examples/classes/Subsub1Class.dump")
             Assertions.assertThat(apiSubsub1.readText()).isEqualToIgnoringNewLines(apiSubsub1Expected)
 
             val apiSubsub2 = rootProjectDir.resolve("sub1/subsub2/api/subsub2.api")
             assertTrue(apiSubsub2.exists(), "api dump file ${apiSubsub2.path} should exist")
-            val apiSubsub2Expected = readFileList("examples/classes/Subsub2Class.dump")
+            val apiSubsub2Expected = readFileList("/examples/classes/Subsub2Class.dump")
             Assertions.assertThat(apiSubsub2.readText()).isEqualToIgnoringNewLines(apiSubsub2Expected)
 
             val apiSub2 = rootProjectDir.resolve("sub2/api/sub2.api")

--- a/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnSubTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnSubTests.kt
@@ -33,29 +33,29 @@ internal class SubprojectsWithPluginOnSubTests : BaseKotlinGradleTest() {
      */
     private fun BaseKotlinScope.createProjectHierarchyWithPluginOnSub1() {
         settingsGradleKts {
-            resolve("examples/gradle/settings/settings-with-hierarchy.gradle.kts")
+            resolve("/examples/gradle/settings/settings-with-hierarchy.gradle.kts")
         }
         buildGradleKts {
-            resolve("examples/gradle/base/withoutPlugin.gradle.kts")
+            resolve("/examples/gradle/base/withoutPlugin.gradle.kts")
         }
         dir("sub1") {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin-noKotlinVersion.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin-noKotlinVersion.gradle.kts")
             }
             dir("subsub1") {
                 buildGradleKts {
-                    resolve("examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
+                    resolve("/examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
                 }
             }
             dir("subsub2") {
                 buildGradleKts {
-                    resolve("examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
+                    resolve("/examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
                 }
             }
         }
         dir("sub2") {
             buildGradleKts {
-                resolve("examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
+                resolve("/examples/gradle/base/withoutPlugin-noKotlinVersion.gradle.kts")
             }
         }
     }
@@ -170,10 +170,10 @@ internal class SubprojectsWithPluginOnSubTests : BaseKotlinGradleTest() {
             dir("sub1") {
                 dir("subsub2") {
                     kotlin("Subsub2Class.kt") {
-                        resolve("examples/classes/Subsub2Class.kt")
+                        resolve("/examples/classes/Subsub2Class.kt")
                     }
                     apiFile(projectName = "subsub2") {
-                        resolve("examples/classes/Subsub2Class.dump")
+                        resolve("/examples/classes/Subsub2Class.dump")
                     }
                 }
             }
@@ -198,18 +198,18 @@ internal class SubprojectsWithPluginOnSubTests : BaseKotlinGradleTest() {
 
                 dir("subsub1") {
                     kotlin("Subsub1Class.kt") {
-                        resolve("examples/classes/Subsub1Class.kt")
+                        resolve("/examples/classes/Subsub1Class.kt")
                     }
                     apiFile(projectName = "subsub1") {
-                        resolve("examples/classes/Subsub1Class.dump")
+                        resolve("/examples/classes/Subsub1Class.dump")
                     }
                 }
                 dir("subsub2") {
                     kotlin("Subsub2Class.kt") {
-                        resolve("examples/classes/Subsub2Class.kt")
+                        resolve("/examples/classes/Subsub2Class.kt")
                     }
                     apiFile(projectName = "subsub2") {
-                        resolve("examples/classes/Subsub2Class.dump")
+                        resolve("/examples/classes/Subsub2Class.dump")
                     }
                 }
             }
@@ -256,12 +256,12 @@ internal class SubprojectsWithPluginOnSubTests : BaseKotlinGradleTest() {
             dir("sub1") {
                 dir("subsub1") {
                     kotlin("Subsub1Class.kt") {
-                        resolve("examples/classes/Subsub1Class.kt")
+                        resolve("/examples/classes/Subsub1Class.kt")
                     }
                 }
                 dir("subsub2") {
                     kotlin("Subsub2Class.kt") {
-                        resolve("examples/classes/Subsub2Class.kt")
+                        resolve("/examples/classes/Subsub2Class.kt")
                     }
                 }
             }
@@ -286,12 +286,12 @@ internal class SubprojectsWithPluginOnSubTests : BaseKotlinGradleTest() {
 
             val apiSubsub1 = rootProjectDir.resolve("sub1/subsub1/api/subsub1.api")
             assertTrue(apiSubsub1.exists(), "api dump file ${apiSubsub1.path} should exist")
-            val apiSubsub1Expected = readFileList("examples/classes/Subsub1Class.dump")
+            val apiSubsub1Expected = readFileList("/examples/classes/Subsub1Class.dump")
             Assertions.assertThat(apiSubsub1.readText()).isEqualToIgnoringNewLines(apiSubsub1Expected)
 
             val apiSubsub2 = rootProjectDir.resolve("sub1/subsub2/api/subsub2.api")
             assertTrue(apiSubsub2.exists(), "api dump file ${apiSubsub2.path} should exist")
-            val apiSubsub2Expected = readFileList("examples/classes/Subsub2Class.dump")
+            val apiSubsub2Expected = readFileList("/examples/classes/Subsub2Class.dump")
             Assertions.assertThat(apiSubsub2.readText()).isEqualToIgnoringNewLines(apiSubsub2Expected)
 
             val apiSub2 = rootProjectDir.resolve("sub2/api/sub2.api")


### PR DESCRIPTION
Minor QOL improvement in the Test DSL. Annotating the file paths with `@Language("file-reference")` means the files can be opened in IntelliJ by cmd+clicking the file path.

Missing files are highlighted.

![image](https://user-images.githubusercontent.com/897017/222208201-236f47b0-c968-4fef-bcd0-b72dab36d6a6.png)

### Summary of changes

For this to work, 

* all paths need to be absolute from the root resources (all paths were already the full file path, I just needed to add the base `/`)
* use `java.getResouce()` instead of `classLoader.getResource()`.

### Impact

This is a test-only change and does not have any impact on the library.
