### PR TITLE
ignoredClasses ignores classes that match a substring of the class name

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/test/IgnoredClassesTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/IgnoredClassesTests.kt
@@ -96,4 +96,33 @@ internal class IgnoredClassesTests : BaseKotlinGradleTest() {
             Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
         }
     }
+
+    @Test
+    fun `apiDump should dump class whose name is a subsset of another class that is excluded via ignoredClasses`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/ignoredClasses/oneValidFullyQualifiedClass.gradle.kts")
+            }
+            kotlin("BuildConfig.kt") {
+                resolve("examples/classes/BuildConfig.kt")
+            }
+            kotlin("BuildCon.kt") {
+                resolve("examples/classes/BuildCon.kt")
+            }
+
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            assertTrue(rootProjectApiDump.exists(), "api dump file should exist")
+
+            val expected = readFileList("examples/classes/BuildCon.dump")
+            Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
+        }
+    }
 }

--- a/src/functionalTest/resources/examples/classes/BuildCon.dump
+++ b/src/functionalTest/resources/examples/classes/BuildCon.dump
@@ -1,0 +1,6 @@
+public final class com/company/BuildCon {
+	public fun <init> ()V
+	public final fun f1 ()I
+	public final fun getP1 ()I
+}
+

--- a/src/functionalTest/resources/examples/classes/BuildCon.kt
+++ b/src/functionalTest/resources/examples/classes/BuildCon.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package com.company
+
+public class BuildCon {
+    public val p1 = 1
+
+    public fun f1() = p1
+}

--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -244,7 +244,7 @@ private fun ClassBinarySignature.isInPackages(packageNames: Collection<String>):
     packageNames.any { packageName -> name.startsWith(packageName) }
 
 private fun ClassBinarySignature.isInClasses(classNames: Collection<String>): Boolean =
-    classNames.any { className -> className.startsWith(name) }
+    classNames.any { className -> className.startsWith("$name/") }
 
 private fun JarFile.classEntries() = Sequence { entries().iterator() }.filter {
     !it.isDirectory && it.name.endsWith(".class") && !it.name.startsWith("META-INF/")


### PR DESCRIPTION
If I have two classes com.example.Hello and com.example.HelloWorld, and I add com.example.HelloWorld to my ignore classes list, apiDump will not generate dump information for com.example.Hello.

Closes #135 