### PR TITLE
Add possibility to check flavoured android modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ apiValidation {
      * Flag to programmatically disable compatibility validator
      */
     validationDisabled = true
+
+    /**
+     * flavour to be tested in flavoured Android modules
+     */
+    testedFlavourName = "blue"
 }
 ```
 
@@ -122,6 +127,11 @@ apiValidation {
      * Flag to programmatically disable compatibility validator
      */
     validationDisabled = false
+
+    /**
+     * flavour to be tested in flavoured Android modules
+     */
+    testedFlavourName = "blue"
 }
 ```
 

--- a/src/functionalTest/resources/examples/classes/FlavourGreen.kt
+++ b/src/functionalTest/resources/examples/classes/FlavourGreen.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package examples.classes
+
+class FlavourGreen {
+
+    fun foo(): String = "foo"
+    internal fun bar(): String = "bar"
+
+}

--- a/src/functionalTest/resources/examples/classes/FlavourRed.kt
+++ b/src/functionalTest/resources/examples/classes/FlavourRed.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package examples.classes
+
+class FlavourRed {
+
+    fun foo(): String = "foo"
+    internal fun bar(): String = "bar"
+
+}

--- a/src/functionalTest/resources/examples/classes/KotlinFlavour.kt
+++ b/src/functionalTest/resources/examples/classes/KotlinFlavour.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2016-2022 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package examples.classes
+
+class KotlinFlavour {
+
+    fun foo(): String = "foo"
+    internal fun bar(): String = "bar"
+
+}

--- a/src/functionalTest/resources/examples/classes/KotlinFlavouredLib.dump
+++ b/src/functionalTest/resources/examples/classes/KotlinFlavouredLib.dump
@@ -1,0 +1,23 @@
+public final class examples/classes/FlavourGreen {
+	public fun <init> ()V
+	public final fun foo ()Ljava/lang/String;
+}
+
+public final class examples/classes/KotlinFlavour {
+	public fun <init> ()V
+	public final fun foo ()Ljava/lang/String;
+}
+
+public final class examples/classes/KotlinLib {
+	public fun <init> ()V
+	public final fun foo ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/kotlinx/android/kotlin/library/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field FLAVOR Ljava/lang/String;
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+

--- a/src/functionalTest/resources/examples/gradle/base/androidFlavouredKotlinLibrary.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/androidFlavouredKotlinLibrary.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright 2016-2022 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
+import org.jetbrains.kotlin.gradle.plugin.*
 plugins {
     id("com.android.library")
     id("kotlin-android")
@@ -32,8 +33,21 @@ android {
         }
     }
 
+    flavorDimensions += "brand"
+    productFlavors {
+        create("green") {
+            dimension = "brand"
+        }
+        create("red") {
+            dimension = "brand"
+        }
+    }
 }
 
+apiValidation {
+    testedFlavourName = "green"
+    additionalSourceSets.add("green")
+}
 dependencies {
     // no dependencies required
 }

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -64,4 +64,10 @@ open class ApiValidationExtension {
      * By default, only the `main` source set is checked.
      */
     public var additionalSourceSets: MutableSet<String> = HashSet()
+
+    /**
+     * In Android projects with multiple flavour,
+     * it specifies the flavour you want to test (assuming projects have same API)
+     */
+    public var testedFlavourName: String? = null
 }


### PR DESCRIPTION
Added the option to test flavoured android modules thanks to `testedFlavourName` parameter 
it would solve https://github.com/Kotlin/binary-compatibility-validator/issues/24 