### PR TITLE
Filter out $EntriesMappings class for Kotlin's 1.9 feature 'Enum entries'

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,12 +66,6 @@ val createClasspathManifest = tasks.register("createClasspathManifest") {
 val kotlinVersion: String by project
 val androidGradlePluginVersion: String = "7.2.2"
 
-configurations.implementation {
-    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
-    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
-    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
-}
-
 dependencies {
     implementation(gradleApi())
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.6.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,7 +110,8 @@ java {
 tasks {
     compileTestKotlin {
         kotlinOptions {
-            languageVersion = "1.6"
+            languageVersion = "1.9"
+            freeCompilerArgs += "-Xsuppress-version-warnings"
         }
     }
     test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=0.13.2-SNAPSHOT
 group=org.jetbrains.kotlinx
 
-kotlinVersion=1.8.10
+kotlinVersion=1.8.20
 pluginPublishVersion=0.10.1
 
 kotlin.stdlib.default.dependency=false

--- a/src/main/kotlin/api/AsmMetadataLoading.kt
+++ b/src/main/kotlin/api/AsmMetadataLoading.kt
@@ -32,6 +32,7 @@ fun ClassNode.isEffectivelyPublic(classVisibility: ClassVisibility?) =
             && !isLocal()
             && !isWhenMappings()
             && !isSyntheticAnnotationClass()
+            && !isEnumEntriesMappings()
             && (classVisibility?.isPublic(isPublishedApi()) ?: true)
 
 
@@ -40,6 +41,7 @@ fun ClassNode.isLocal() = outerMethod != null
 fun ClassNode.isInner() = innerClassNode != null
 fun ClassNode.isWhenMappings() = isSynthetic(access) && name.endsWith("\$WhenMappings")
 fun ClassNode.isSyntheticAnnotationClass() = isSynthetic(access) && name.contains("\$annotationImpl\$")
+fun ClassNode.isEnumEntriesMappings() = isSynthetic(access) && name.endsWith("\$EntriesMappings")
 
 val ClassNode.effectiveAccess: Int get() = innerClassNode?.access ?: access
 val ClassNode.outerClassName: String? get() = innerClassNode?.outerName

--- a/src/test/kotlin/cases/enums/EnumClass.kt
+++ b/src/test/kotlin/cases/enums/EnumClass.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package cases.enums
+
+enum class EnumClass { A, B, C }

--- a/src/test/kotlin/cases/enums/JavaEnum.java
+++ b/src/test/kotlin/cases/enums/JavaEnum.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package cases.enums;
+
+public enum JavaEnum {
+    JA, JB, JC
+}

--- a/src/test/kotlin/cases/enums/entries.kt
+++ b/src/test/kotlin/cases/enums/entries.kt
@@ -1,0 +1,8 @@
+package cases.enums
+
+@OptIn(ExperimentalStdlibApi::class)
+fun test() {
+    EnumClass.entries.forEach {
+        println(it)
+    }
+}

--- a/src/test/kotlin/cases/enums/entries.kt
+++ b/src/test/kotlin/cases/enums/entries.kt
@@ -5,4 +5,9 @@ fun test() {
     EnumClass.entries.forEach {
         println(it)
     }
+
+    JavaEnum.entries.forEach {
+        println(it)
+    }
 }
+

--- a/src/test/kotlin/cases/enums/enums.txt
+++ b/src/test/kotlin/cases/enums/enums.txt
@@ -11,3 +11,11 @@ public final class cases/enums/EnumClass : java/lang/Enum {
 	public static fun values ()[Lcases/enums/EnumClass;
 }
 
+public final class cases/enums/JavaEnum : java/lang/Enum {
+	public static final field JA Lcases/enums/JavaEnum;
+	public static final field JB Lcases/enums/JavaEnum;
+	public static final field JC Lcases/enums/JavaEnum;
+	public static fun valueOf (Ljava/lang/String;)Lcases/enums/JavaEnum;
+	public static fun values ()[Lcases/enums/JavaEnum;
+}
+

--- a/src/test/kotlin/cases/enums/enums.txt
+++ b/src/test/kotlin/cases/enums/enums.txt
@@ -1,0 +1,13 @@
+public final class cases/enums/EntriesKt {
+	public static final fun test ()V
+}
+
+public final class cases/enums/EnumClass : java/lang/Enum {
+	public static final field A Lcases/enums/EnumClass;
+	public static final field B Lcases/enums/EnumClass;
+	public static final field C Lcases/enums/EnumClass;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcases/enums/EnumClass;
+	public static fun values ()[Lcases/enums/EnumClass;
+}
+

--- a/src/test/kotlin/cases/whenMappings/whenMappings.txt
+++ b/src/test/kotlin/cases/whenMappings/whenMappings.txt
@@ -7,6 +7,7 @@ public final class cases/whenMappings/SampleEnum : java/lang/Enum {
 	public static final field A Lcases/whenMappings/SampleEnum;
 	public static final field B Lcases/whenMappings/SampleEnum;
 	public static final field C Lcases/whenMappings/SampleEnum;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcases/whenMappings/SampleEnum;
 	public static fun values ()[Lcases/whenMappings/SampleEnum;
 }

--- a/src/test/kotlin/tests/CasesPublicAPITest.kt
+++ b/src/test/kotlin/tests/CasesPublicAPITest.kt
@@ -55,6 +55,8 @@ class CasesPublicAPITest {
 
     @Test fun whenMappings() { snapshotAPIAndCompare(testName.methodName) }
 
+    @Test fun enums() { snapshotAPIAndCompare(testName.methodName) }
+
     private fun snapshotAPIAndCompare(testClassRelativePath: String, nonPublicMarkers: Set<String> = emptySet()) {
         val testClassPaths = baseClassPaths.map { it.resolve(testClassRelativePath) }
         val testClasses = testClassPaths.flatMap { it.listFiles().orEmpty().asIterable() }


### PR DESCRIPTION
Kotlin compiler generates synthetic class holding EnumEntries starting from 1.9. This change filters out such classes from the API dump.

Closes #141 