### PR TITLE
Add a config for apiCheck only failing on deletions and changes, and ignoring additions

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/test/IgnoredAdditionsTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/IgnoredAdditionsTests.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.test
+
+import kotlinx.validation.api.BaseKotlinGradleTest
+import kotlinx.validation.api.assertTaskSuccess
+import kotlinx.validation.api.buildGradleKts
+import kotlinx.validation.api.emptyApiFile
+import kotlinx.validation.api.kotlin
+import kotlinx.validation.api.resolve
+import kotlinx.validation.api.runner
+import kotlinx.validation.api.test
+import org.junit.Test
+
+internal class IgnoredAdditionsTests : BaseKotlinGradleTest() {
+
+    @Test
+    fun `apiCheck should pass, when a public class is not in api-File, but is ignoreAdditions is enabled`() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/ignoreAdditions/ignoreAdditions.gradle.kts")
+            }
+
+            kotlin("BuildConfig.kt") {
+                resolve("examples/classes/BuildConfig.kt")
+            }
+
+            emptyApiFile(projectName = rootProjectDir.name)
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/ignoreAdditions/ignoreAdditions.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/ignoreAdditions/ignoreAdditions.gradle.kts
@@ -1,0 +1,3 @@
+configure<kotlinx.validation.ApiValidationExtension> {
+    ignoreAdditions = true
+}

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -64,4 +64,9 @@ open class ApiValidationExtension {
      * By default, only the `main` source set is checked.
      */
     public var additionalSourceSets: MutableSet<String> = HashSet()
+
+    /**
+     * Only fail on API deletion and changes, and not on additions.
+     */
+    public var ignoreAdditions = false
 }

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -262,7 +262,11 @@ private fun Project.configureCheckTasks(
         isEnabled = apiCheckEnabled(projectName, extension) && apiBuild.map { it.enabled }.getOrElse(true)
         group = "verification"
         description = "Checks signatures of public API against the golden value in API folder for $projectName"
-        compareApiDumps(apiReferenceDir = apiCheckDir.get(), apiBuildDir = apiBuildDir.get())
+        compareApiDumps(
+            apiReferenceDir = apiCheckDir.get(),
+            apiBuildDir = apiBuildDir.get(),
+            ignoreAdditions = extension.ignoreAdditions
+        )
         dependsOn(apiBuild)
     }
 


### PR DESCRIPTION
In places where we're using this plug-in, we've ended up ignoring the apiCheck failures at times, due to many failures being due to new APIs being added, which are not breaking changes. This new configuration makes it so that apiCheck only fails if the existing API lines have been `change`d or `delete`d, indicating either new arguments being added to an exisitng function/method or an existing function/method being deleted. Both of these situations are potential breaking changes and what we want to fail the bulid for.

