### PR TITLE
Support KLib validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ val androidGradlePluginVersion: String = "7.2.2"
 dependencies {
     implementation(gradleApi())
     implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.6.2")
+    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
     implementation("org.ow2.asm:asm:9.2")
     implementation("org.ow2.asm:asm-tree:9.2")
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=0.13.2-SNAPSHOT
 group=org.jetbrains.kotlinx
 
-kotlinVersion=1.8.20
+kotlinVersion=1.9.20-Beta2
 pluginPublishVersion=0.10.1
 
 kotlin.stdlib.default.dependency=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=0.13.2-SNAPSHOT
 group=org.jetbrains.kotlinx
 
-kotlinVersion=1.9.20-Beta2
+kotlinVersion=1.9.20-RC
 pluginPublishVersion=0.10.1
 
 kotlin.stdlib.default.dependency=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=0.13.2-SNAPSHOT
 group=org.jetbrains.kotlinx
 
-kotlinVersion=1.9.20-RC
+kotlinVersion=1.9.20-RC2
 pluginPublishVersion=0.10.1
 
 kotlin.stdlib.default.dependency=false

--- a/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
@@ -17,4 +17,7 @@ public open class BaseKotlinGradleTest {
     internal val rootProjectDir: File get() = testProjectDir.root
 
     internal val rootProjectApiDump: File get() = rootProjectDir.resolve("api/${rootProjectDir.name}.api")
+
+    internal fun rootProjectAbiDump(target: String, project: String = rootProjectDir.name): File =
+        rootProjectDir.resolve("api/$target/$project.api")
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
@@ -95,7 +95,9 @@ internal fun FileContainer.apiFile(projectName: String, fn: AppendableScope.() -
     }
 }
 
-// TODO
+/**
+ * Shortcut for creating a `api/<target>/<project>.api` descriptor using [file][FileContainer.file]
+ */
 internal fun FileContainer.abiFile(projectName: String, target: String, fn: AppendableScope.() -> Unit) {
     dir(API_DIR) {
         dir(target) {

--- a/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
@@ -95,6 +95,15 @@ internal fun FileContainer.apiFile(projectName: String, fn: AppendableScope.() -
     }
 }
 
+// TODO
+internal fun FileContainer.abiFile(projectName: String, target: String, fn: AppendableScope.() -> Unit) {
+    dir(API_DIR) {
+        dir(target) {
+            file("$projectName.api", fn)
+        }
+    }
+}
+
 // not using default argument in apiFile for clarity in tests (explicit "empty" in the name)
 /**
  * Shortcut for creating an empty `api/<project>.api` descriptor by using [file][FileContainer.file]
@@ -161,3 +170,26 @@ private fun GradleRunner.addPluginTestRuntimeClasspath() = apply {
     val pluginClasspath = pluginClasspath + cpResource.readLines().map { File(it) }
     withPluginClasspath(pluginClasspath)
 }
+
+internal val nativeTargets = listOf(
+    "linuxX64",
+    "linuxArm64",
+    "mingwX64",
+    "macosX64",
+    "macosArm64",
+    "iosX64",
+    "iosArm64",
+    "iosSimulatorArm64",
+    "tvosX64",
+    "tvosArm64",
+    "tvosSimulatorArm64",
+    "watchosArm32",
+    "watchosArm64",
+    "watchosX64",
+    "watchosSimulatorArm64",
+    "watchosDeviceArm64",
+    "androidNativeArm32",
+    "androidNativeArm64",
+    "androidNativeX64",
+    "androidNativeX86"
+)

--- a/src/functionalTest/kotlin/kotlinx/validation/test/IgnoredClassesTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/IgnoredClassesTests.kt
@@ -15,6 +15,7 @@ import kotlinx.validation.api.resolve
 import kotlinx.validation.api.runner
 import kotlinx.validation.api.test
 import org.assertj.core.api.Assertions
+import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertTrue
 

--- a/src/functionalTest/kotlin/kotlinx/validation/test/KLibVerificationTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/KLibVerificationTests.kt
@@ -14,29 +14,6 @@ import org.junit.Test
 import java.io.File
 import kotlin.test.assertTrue
 
-private val nativeTargets = listOf(
-    "linuxX64",
-    "linuxArm64",
-    "mingwX64",
-    "macosX64",
-    "macosArm64",
-    "iosX64",
-    "iosArm64",
-    "iosSimulatorArm64",
-    "tvosX64",
-    "tvosArm64",
-    "tvosSimulatorArm64",
-    "watchosArm32",
-    "watchosArm64",
-    "watchosX64",
-    "watchosSimulatorArm64",
-    "watchosDeviceArm64",
-    "androidNativeArm32",
-    "androidNativeArm64",
-    "androidNativeX64",
-    "androidNativeX86"
-)
-
 internal class KLibVerificationTests : BaseKotlinGradleTest() {
     @Test
     fun `apiDump for native targets`() {
@@ -47,11 +24,9 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
             buildGradleKts {
                 resolve("examples/gradle/base/withNativePlugin.gradle.kts")
             }
-
             kotlin("AnotherBuildConfig.kt", "commonMain") {
                 resolve("examples/classes/AnotherBuildConfig.kt")
             }
-
             runner {
                 arguments.add(":apiDump")
             }
@@ -73,7 +48,159 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
         }
     }
 
-    // todo: test mixed jvm + native
-    // todo: test native with different source sets
-    // todo: test markers and filtration
+    @Test
+    fun `apiCheck for native targets`() {
+        val runner = test {
+            settingsGradleKts {
+                resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+            }
+            buildGradleKts {
+                resolve("examples/gradle/base/withNativePlugin.gradle.kts")
+            }
+            kotlin("AnotherBuildConfig.kt", "commonMain") {
+                resolve("examples/classes/AnotherBuildConfig.kt")
+            }
+
+            nativeTargets.forEach {
+                abiFile(projectName = "testproject", target = it) {
+                    resolve("examples/classes/AnotherBuildConfig.klib.dump")
+                }
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+
+    @Test
+    fun `apiCheck for native targets should fail when a class is not in a dump`() {
+        val runner = test {
+            settingsGradleKts {
+                resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+            }
+            buildGradleKts {
+                resolve("examples/gradle/base/withNativePlugin.gradle.kts")
+            }
+            kotlin("BuildConfig.kt", "commonMain") {
+                resolve("examples/classes/BuildConfig.kt")
+            }
+
+            nativeTargets.forEach {
+                abiFile(projectName = "testproject", target = it) {}
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.buildAndFail().apply {
+            val dumpOutput =
+                "  @@ -1,1 +1,13 @@\n" +
+                        "  +// Rendering settings:\n" +
+                        "  +// - Signature version: 2\n" +
+                        "  +// - Show manifest properties: false\n" +
+                        "  +// - Show declarations: true\n" +
+                        "   \n" +
+                        "  +// Library unique name: <testproject>\n" +
+                        "  +final class com.company/BuildConfig { // com.company/BuildConfig|null[0]\n" +
+                        "  +    final val property // com.company/BuildConfig.property|{}property[0]\n" +
+                        "  +        final fun <get-property>(): kotlin/Int // com.company/BuildConfig.property.<get-property>|<get-property>(){}[0]\n" +
+                        "  +    constructor <init>() // com.company/BuildConfig.<init>|<init>(){}[0]\n" +
+                        "  +    final fun function(): kotlin/Int // com.company/BuildConfig.function|function(){}[0]\n" +
+                        "  +}\n" +
+                        "  +"
+            Assertions.assertThat(output).contains(dumpOutput)
+            tasks.filter { it.path.endsWith("ApiCheck") }
+                .forEach {
+                    assertTaskFailure(it.path)
+                }
+        }
+    }
+
+    @Test
+    fun `apiDump should include target-specific sources`() {
+        val runner = test {
+            settingsGradleKts {
+                resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+            }
+            buildGradleKts {
+                resolve("examples/gradle/base/withNativePlugin.gradle.kts")
+            }
+            kotlin("AnotherBuildConfig.kt", "commonMain") {
+                resolve("examples/classes/AnotherBuildConfig.kt")
+            }
+            kotlin("AnotherBuildConfigLinuxArm64.kt", "linuxArm64Main") {
+                resolve("examples/classes/AnotherBuildConfigLinuxArm64.kt")
+            }
+
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            // not common, but built from the common source set
+            val commonFile = rootProjectAbiDump("linuxX64", "testproject")
+            val specializedFile = rootProjectAbiDump("linuxArm64", "testproject")
+
+            // all hosts support Linux target, that's why the test is using them
+            assertTrue(commonFile.exists(), "No dump for linuxX64")
+            assertTrue(specializedFile.exists(), "No dump for linuxArm64")
+
+            val expectedCommon = readFileList("examples/classes/AnotherBuildConfig.klib.dump")
+            val expectedSpecialized = readFileList(
+                "examples/classes/AnotherBuildConfigLinuxArm64Extra.klib.dump")
+
+            Assertions.assertThat(commonFile.readText()).isEqualToIgnoringNewLines(expectedCommon)
+            Assertions.assertThat(specializedFile.readText()).isEqualToIgnoringNewLines(expectedSpecialized)
+        }
+    }
+
+    @Test
+    fun `apiDump with native targets along with JVM target`() {
+        val runner = test {
+            settingsGradleKts {
+                resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+            }
+            buildGradleKts {
+                resolve("examples/gradle/base/withNativePlugin.gradle.kts")
+                resolve("examples/gradle/base/enableJvmInWithNativePlugin.gradle.kts")
+            }
+            kotlin("AnotherBuildConfig.kt", "commonMain") {
+                resolve("examples/classes/AnotherBuildConfig.kt")
+            }
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            val generatedDumps = nativeTargets
+                .map { rootProjectAbiDump(target = it, project = "testproject") }
+                .filter(File::exists)
+            assertTrue(generatedDumps.isNotEmpty(), "There are no dumps generated for KLibs")
+
+            val expected = readFileList("examples/classes/AnotherBuildConfig.klib.dump")
+
+            generatedDumps.forEach {
+                Assertions.assertThat(it.readText()).isEqualToIgnoringNewLines(expected)
+            }
+
+            val jvmApiDump = rootProjectAbiDump("jvm", "testproject")
+            assertTrue(jvmApiDump.exists(), "No API dump for JVM")
+
+            val jvmExpected = readFileList("examples/classes/AnotherBuildConfig.dump")
+            Assertions.assertThat(jvmApiDump.readText()).isEqualToIgnoringNewLines(jvmExpected)
+        }
+    }
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/KLibVerificationTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/KLibVerificationTests.kt
@@ -279,7 +279,7 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
     }
 
     @Test
-    fun `apiDump should ignore all entities from a package listed in ingoredPacakges`() {
+    fun `apiDump should ignore all entities from a package listed in ingoredPackages`() {
         val runner = test {
             settingsGradleKts {
                 resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
@@ -293,6 +293,9 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
             }
             kotlin("AnotherBuildConfig.kt", "commonMain") {
                 resolve("examples/classes/AnotherBuildConfig.kt")
+            }
+            kotlin("SubPackage.kt", "commonMain") {
+                resolve("examples/classes/SubPackage.kt")
             }
 
             runner {

--- a/src/functionalTest/kotlin/kotlinx/validation/test/KLibVerificationTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/KLibVerificationTests.kt
@@ -10,9 +10,25 @@ import kotlinx.validation.api.buildGradleKts
 import kotlinx.validation.api.resolve
 import kotlinx.validation.api.test
 import org.assertj.core.api.Assertions
+import org.gradle.testkit.runner.BuildResult
 import org.junit.Test
 import java.io.File
 import kotlin.test.assertTrue
+
+private fun KLibVerificationTests.checkKlibDump(buildResult: BuildResult, expectedDumpFileName: String, projectName: String = "testproject") {
+    buildResult.assertTaskSuccess(":apiDump")
+
+    val generatedDumps = nativeTargets
+        .map { rootProjectAbiDump(target = it, project = projectName) }
+        .filter(File::exists)
+    assertTrue(generatedDumps.isNotEmpty(), "There are no dumps generated for KLibs")
+
+    val expected = readFileList(expectedDumpFileName)
+
+    generatedDumps.forEach {
+        Assertions.assertThat(it.readText()).isEqualToIgnoringNewLines(expected)
+    }
+}
 
 internal class KLibVerificationTests : BaseKotlinGradleTest() {
     @Test
@@ -32,20 +48,7 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
             }
         }
 
-        runner.build().apply {
-            assertTaskSuccess(":apiDump")
-
-            val generatedDumps = nativeTargets
-                .map { rootProjectAbiDump(target = it, project = "testproject") }
-                .filter(File::exists)
-            assertTrue(generatedDumps.isNotEmpty(), "There are no dumps generated for KLibs")
-
-            val expected = readFileList("examples/classes/TopLevelDeclarations.klib.dump")
-
-            generatedDumps.forEach {
-                Assertions.assertThat(it.readText()).isEqualToIgnoringNewLines(expected)
-            }
-        }
+        checkKlibDump(runner.build(), "examples/classes/TopLevelDeclarations.klib.dump")
     }
 
     @Test
@@ -184,18 +187,7 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
         }
 
         runner.build().apply {
-            assertTaskSuccess(":apiDump")
-
-            val generatedDumps = nativeTargets
-                .map { rootProjectAbiDump(target = it, project = "testproject") }
-                .filter(File::exists)
-            assertTrue(generatedDumps.isNotEmpty(), "There are no dumps generated for KLibs")
-
-            val expected = readFileList("examples/classes/AnotherBuildConfig.klib.dump")
-
-            generatedDumps.forEach {
-                Assertions.assertThat(it.readText()).isEqualToIgnoringNewLines(expected)
-            }
+            checkKlibDump(this, "examples/classes/AnotherBuildConfig.klib.dump")
 
             val jvmApiDump = rootProjectAbiDump("jvm", "testproject")
             assertTrue(jvmApiDump.exists(), "No API dump for JVM")
@@ -227,20 +219,7 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
             }
         }
 
-        runner.build().apply {
-            assertTaskSuccess(":apiDump")
-
-            val generatedDumps = nativeTargets
-                .map { rootProjectAbiDump(target = it, project = "testproject") }
-                .filter(File::exists)
-            assertTrue(generatedDumps.isNotEmpty(), "There are no dumps generated for KLibs")
-
-            val expected = readFileList("examples/classes/AnotherBuildConfig.klib.dump")
-
-            generatedDumps.forEach {
-                Assertions.assertThat(it.readText()).isEqualToIgnoringNewLines(expected)
-            }
-        }
+        checkKlibDump(runner.build(), "examples/classes/AnotherBuildConfig.klib.dump")
     }
 
     @Test
@@ -262,20 +241,7 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
             }
         }
 
-        runner.build().apply {
-            assertTaskSuccess(":apiDump")
-
-            val generatedDumps = nativeTargets
-                .map { rootProjectAbiDump(target = it, project = "testproject") }
-                .filter(File::exists)
-            assertTrue(generatedDumps.isNotEmpty(), "There are no dumps generated for KLibs")
-
-            val expected = readFileList("examples/classes/AnotherBuildConfig.klib.dump")
-
-            generatedDumps.forEach {
-                Assertions.assertThat(it.readText()).isEqualToIgnoringNewLines(expected)
-            }
-        }
+        checkKlibDump(runner.build(), "examples/classes/AnotherBuildConfig.klib.dump")
     }
 
     @Test
@@ -303,20 +269,7 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
             }
         }
 
-        runner.build().apply {
-            assertTaskSuccess(":apiDump")
-
-            val generatedDumps = nativeTargets
-                .map { rootProjectAbiDump(target = it, project = "testproject") }
-                .filter(File::exists)
-            assertTrue(generatedDumps.isNotEmpty(), "There are no dumps generated for KLibs")
-
-            val expected = readFileList("examples/classes/AnotherBuildConfig.klib.dump")
-
-            generatedDumps.forEach {
-                Assertions.assertThat(it.readText()).isEqualToIgnoringNewLines(expected)
-            }
-        }
+        checkKlibDump(runner.build(), "examples/classes/AnotherBuildConfig.klib.dump")
     }
 
     @Test
@@ -341,20 +294,7 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
             }
         }
 
-        runner.build().apply {
-            assertTaskSuccess(":apiDump")
-
-            val generatedDumps = nativeTargets
-                .map { rootProjectAbiDump(target = it, project = "testproject") }
-                .filter(File::exists)
-            assertTrue(generatedDumps.isNotEmpty(), "There are no dumps generated for KLibs")
-
-            val expected = readFileList("examples/classes/HiddenDeclarations.klib.dump")
-
-            generatedDumps.forEach {
-                Assertions.assertThat(it.readText()).isEqualToIgnoringNewLines(expected)
-            }
-        }
+        checkKlibDump(runner.build(), "examples/classes/HiddenDeclarations.klib.dump")
     }
 
     @Test
@@ -376,19 +316,7 @@ internal class KLibVerificationTests : BaseKotlinGradleTest() {
             }
         }
 
-        runner.build().apply {
-            assertTaskSuccess(":apiDump")
-
-            val generatedDumps = nativeTargets
-                .map { rootProjectAbiDump(target = it, project = "testproject") }
-                .filter(File::exists)
-            assertTrue(generatedDumps.isNotEmpty(), "There are no dumps generated for KLibs")
-
-            val expected = readFileList("examples/classes/Subclasses.klib.dump")
-            generatedDumps.forEach {
-                Assertions.assertThat(it.readText()).isEqualToIgnoringNewLines(expected)
-            }
-        }
+        checkKlibDump(runner.build(), "examples/classes/Subclasses.klib.dump")
     }
 
     @Test

--- a/src/functionalTest/kotlin/kotlinx/validation/test/KLibVerificationTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/KLibVerificationTests.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.test
+
+import kotlinx.validation.api.*
+import kotlinx.validation.api.buildGradleKts
+import kotlinx.validation.api.resolve
+import kotlinx.validation.api.test
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertTrue
+
+private val nativeTargets = listOf(
+    "linuxX64",
+    "linuxArm64",
+    "mingwX64",
+    "macosX64",
+    "macosArm64",
+    "iosX64",
+    "iosArm64",
+    "iosSimulatorArm64",
+    "tvosX64",
+    "tvosArm64",
+    "tvosSimulatorArm64",
+    "watchosArm32",
+    "watchosArm64",
+    "watchosX64",
+    "watchosSimulatorArm64",
+    "watchosDeviceArm64",
+    "androidNativeArm32",
+    "androidNativeArm64",
+    "androidNativeX64",
+    "androidNativeX86"
+)
+
+internal class KLibVerificationTests : BaseKotlinGradleTest() {
+    @Test
+    fun `apiDump for native targets`() {
+        val runner = test {
+            settingsGradleKts {
+                resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+            }
+            buildGradleKts {
+                resolve("examples/gradle/base/withNativePlugin.gradle.kts")
+            }
+
+            kotlin("AnotherBuildConfig.kt", "commonMain") {
+                resolve("examples/classes/AnotherBuildConfig.kt")
+            }
+
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            val generatedDumps = nativeTargets
+                .map { rootProjectAbiDump(target = it, project = "testproject") }
+                .filter(File::exists)
+            assertTrue(generatedDumps.isNotEmpty(), "There are no dumps generated for KLibs")
+
+            val expected = readFileList("examples/classes/AnotherBuildConfig.klib.dump")
+
+            generatedDumps.forEach {
+                Assertions.assertThat(it.readText()).isEqualToIgnoringNewLines(expected)
+            }
+        }
+    }
+
+    // todo: test mixed jvm + native
+    // todo: test native with different source sets
+    // todo: test markers and filtration
+}

--- a/src/functionalTest/kotlin/kotlinx/validation/test/NonPublicMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/NonPublicMarkersTest.kt
@@ -35,4 +35,36 @@ class NonPublicMarkersTest : BaseKotlinGradleTest() {
             assertTaskSuccess(":apiCheck")
         }
     }
+
+    @Test
+    fun testIgnoredMarkersOnPropertiesForNativeTargets() {
+        val runner = test {
+            settingsGradleKts {
+                resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+            }
+
+            buildGradleKts {
+                resolve("examples/gradle/base/withNativePlugin.gradle.kts")
+                resolve("examples/gradle/configuration/nonPublicMarkers/markers.gradle.kts")
+            }
+
+            kotlin("Properties.kt", sourceSet = "commonMain") {
+                resolve("examples/classes/Properties.kt")
+            }
+
+            nativeTargets.forEach {
+                abiFile(projectName = "testproject", target = it) {
+                    resolve("examples/classes/Properties.klib.dump")
+                }
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/NonPublicMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/NonPublicMarkersTest.kt
@@ -37,6 +37,7 @@ class NonPublicMarkersTest : BaseKotlinGradleTest() {
     }
 
     @Test
+    @Ignore("https://youtrack.jetbrains.com/issue/KT-62259")
     fun testIgnoredMarkersOnPropertiesForNativeTargets() {
         val runner = test {
             settingsGradleKts {

--- a/src/functionalTest/kotlin/kotlinx/validation/test/PublicMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/PublicMarkersTest.kt
@@ -45,6 +45,7 @@ class PublicMarkersTest : BaseKotlinGradleTest() {
         }
     }
 
+    // Public markers are not supported in KLIB ABI dumps
     @Test
     fun testPublicMarkersForNativeTargets() {
         val runner = test {

--- a/src/functionalTest/kotlin/kotlinx/validation/test/PublicMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/PublicMarkersTest.kt
@@ -10,6 +10,7 @@ import kotlinx.validation.api.buildGradleKts
 import kotlinx.validation.api.kotlin
 import kotlinx.validation.api.resolve
 import kotlinx.validation.api.test
+import org.jetbrains.kotlin.konan.target.HostManager
 import org.junit.Test
 
 class PublicMarkersTest : BaseKotlinGradleTest() {
@@ -32,6 +33,42 @@ class PublicMarkersTest : BaseKotlinGradleTest() {
 
             apiFile(projectName = rootProjectDir.name) {
                 resolve("examples/classes/ClassWithPublicMarkers.dump")
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.withDebug(true).build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+
+    @Test
+    fun testPublicMarkersForNativeTargets() {
+        val runner = test {
+            settingsGradleKts {
+                resolve("examples/gradle/settings/settings-name-testproject.gradle.kts")
+            }
+
+            buildGradleKts {
+                resolve("examples/gradle/base/withNativePlugin.gradle.kts")
+                resolve("examples/gradle/configuration/publicMarkers/markers.gradle.kts")
+            }
+
+            kotlin("ClassWithPublicMarkers.kt", sourceSet = "commonMain") {
+                resolve("examples/classes/ClassWithPublicMarkers.kt")
+            }
+
+            kotlin("ClassInPublicPackage.kt", sourceSet = "commonMain") {
+                resolve("examples/classes/ClassInPublicPackage.kt")
+            }
+
+            nativeTargets.forEach {
+                abiFile(target = it, projectName = "testproject") {
+                    resolve("examples/classes/ClassWithPublicMarkers.klib.dump")
+                }
             }
 
             runner {

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.dump
@@ -1,0 +1,12 @@
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <testproject>
+final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
+    final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
+        final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+    constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+    final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
+}

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfigLinuxArm64.kt
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfigLinuxArm64.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package org.different.pack
+
+fun BuildConfig.linuxArm64Specific(): Int = 42

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfigLinuxArm64Extra.klib.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfigLinuxArm64Extra.klib.dump
@@ -1,0 +1,13 @@
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <testproject>
+final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
+    final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
+        final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+    constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+    final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
+}
+final fun (org.different.pack/BuildConfig).org.different.pack/linuxArm64Specific(): kotlin/Int // org.different.pack/linuxArm64Specific|linuxArm64Specific@org.different.pack.BuildConfig(){}[0]

--- a/src/functionalTest/resources/examples/classes/ClassWithPublicMarkers.klib.dump
+++ b/src/functionalTest/resources/examples/classes/ClassWithPublicMarkers.klib.dump
@@ -11,14 +11,27 @@ final class foo/ClassWithPublicMarkers { // foo/ClassWithPublicMarkers|null[0]
     final var bar2 // foo/ClassWithPublicMarkers.bar2|{}bar2[0]
         final fun <get-bar2>(): kotlin/Int // foo/ClassWithPublicMarkers.bar2.<get-bar2>|<get-bar2>(){}[0]
         final fun <set-bar2>(kotlin/Int) // foo/ClassWithPublicMarkers.bar2.<set-bar2>|<set-bar2>(kotlin.Int){}[0]
+    final var notMarkedPublic // foo/ClassWithPublicMarkers.notMarkedPublic|{}notMarkedPublic[0]
+        final fun <get-notMarkedPublic>(): kotlin/Int // foo/ClassWithPublicMarkers.notMarkedPublic.<get-notMarkedPublic>|<get-notMarkedPublic>(){}[0]
+        final fun <set-notMarkedPublic>(kotlin/Int) // foo/ClassWithPublicMarkers.notMarkedPublic.<set-notMarkedPublic>|<set-notMarkedPublic>(kotlin.Int){}[0]
+    constructor <init>() // foo/ClassWithPublicMarkers.<init>|<init>(){}[0]
     final class MarkedClass { // foo/ClassWithPublicMarkers.MarkedClass|null[0]
         final val bar1 // foo/ClassWithPublicMarkers.MarkedClass.bar1|{}bar1[0]
             final fun <get-bar1>(): kotlin/Int // foo/ClassWithPublicMarkers.MarkedClass.bar1.<get-bar1>|<get-bar1>(){}[0]
         constructor <init>() // foo/ClassWithPublicMarkers.MarkedClass.<init>|<init>(){}[0]
     }
+    final class NotMarkedClass { // foo/ClassWithPublicMarkers.NotMarkedClass|null[0]
+        constructor <init>() // foo/ClassWithPublicMarkers.NotMarkedClass.<init>|<init>(){}[0]
+    }
 }
 open annotation class foo/PublicClass : kotlin/Annotation { // foo/PublicClass|null[0]
     constructor <init>() // foo/PublicClass.<init>|<init>(){}[0]
+}
+open annotation class foo/PublicField : kotlin/Annotation { // foo/PublicField|null[0]
+    constructor <init>() // foo/PublicField.<init>|<init>(){}[0]
+}
+open annotation class foo/PublicProperty : kotlin/Annotation { // foo/PublicProperty|null[0]
+    constructor <init>() // foo/PublicProperty.<init>|<init>(){}[0]
 }
 final class foo.api/ClassInPublicPackage { // foo.api/ClassInPublicPackage|null[0]
     constructor <init>() // foo.api/ClassInPublicPackage.<init>|<init>(){}[0]

--- a/src/functionalTest/resources/examples/classes/ClassWithPublicMarkers.klib.dump
+++ b/src/functionalTest/resources/examples/classes/ClassWithPublicMarkers.klib.dump
@@ -1,0 +1,28 @@
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <testproject>
+final class foo/ClassWithPublicMarkers { // foo/ClassWithPublicMarkers|null[0]
+    final var bar1 // foo/ClassWithPublicMarkers.bar1|{}bar1[0]
+        final fun <get-bar1>(): kotlin/Int // foo/ClassWithPublicMarkers.bar1.<get-bar1>|<get-bar1>(){}[0]
+        final fun <set-bar1>(kotlin/Int) // foo/ClassWithPublicMarkers.bar1.<set-bar1>|<set-bar1>(kotlin.Int){}[0]
+    final var bar2 // foo/ClassWithPublicMarkers.bar2|{}bar2[0]
+        final fun <get-bar2>(): kotlin/Int // foo/ClassWithPublicMarkers.bar2.<get-bar2>|<get-bar2>(){}[0]
+        final fun <set-bar2>(kotlin/Int) // foo/ClassWithPublicMarkers.bar2.<set-bar2>|<set-bar2>(kotlin.Int){}[0]
+    final class MarkedClass { // foo/ClassWithPublicMarkers.MarkedClass|null[0]
+        final val bar1 // foo/ClassWithPublicMarkers.MarkedClass.bar1|{}bar1[0]
+            final fun <get-bar1>(): kotlin/Int // foo/ClassWithPublicMarkers.MarkedClass.bar1.<get-bar1>|<get-bar1>(){}[0]
+        constructor <init>() // foo/ClassWithPublicMarkers.MarkedClass.<init>|<init>(){}[0]
+    }
+}
+open annotation class foo/PublicClass : kotlin/Annotation { // foo/PublicClass|null[0]
+    constructor <init>() // foo/PublicClass.<init>|<init>(){}[0]
+}
+final class foo.api/ClassInPublicPackage { // foo.api/ClassInPublicPackage|null[0]
+    constructor <init>() // foo.api/ClassInPublicPackage.<init>|<init>(){}[0]
+    final class Inner { // foo.api/ClassInPublicPackage.Inner|null[0]
+        constructor <init>() // foo.api/ClassInPublicPackage.Inner.<init>|<init>(){}[0]
+    }
+}

--- a/src/functionalTest/resources/examples/classes/HiddenDeclarations.klib.dump
+++ b/src/functionalTest/resources/examples/classes/HiddenDeclarations.klib.dump
@@ -1,0 +1,9 @@
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <testproject>
+final class examples.classes/VC { // examples.classes/VC|null[0]
+    final var prop // examples.classes/VC.prop|{}prop[0]
+}

--- a/src/functionalTest/resources/examples/classes/HiddenDeclarations.kt
+++ b/src/functionalTest/resources/examples/classes/HiddenDeclarations.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package examples.classes
+
+import annotations.*
+
+@HiddenFunction
+public fun hidden() = Unit
+
+@HiddenProperty
+public val v: Int = 42
+
+@HiddenClass
+public class HC
+
+public class VC @HiddenCtor constructor() {
+    @HiddenProperty
+    public val v: Int = 42
+
+    public var prop: Int = 0
+        @HiddenGetter
+        get() = field
+        @HiddenSetter
+        set(value) {
+            field = value
+        }
+
+    @HiddenProperty
+    public var fullyHiddenProp: Int = 0
+
+    @HiddenFunction
+    public fun m() = Unit
+}

--- a/src/functionalTest/resources/examples/classes/HiddenDeclarations.kt
+++ b/src/functionalTest/resources/examples/classes/HiddenDeclarations.kt
@@ -34,3 +34,10 @@ public class VC @HiddenCtor constructor() {
     @HiddenFunction
     public fun m() = Unit
 }
+
+@HiddenClass
+public class HiddenOuterClass {
+    public class HiddenInnerClass {
+
+    }
+}

--- a/src/functionalTest/resources/examples/classes/NonPublicMarkers.kt
+++ b/src/functionalTest/resources/examples/classes/NonPublicMarkers.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package annotations
+
+@HiddenClass
+@Target(AnnotationTarget.CLASS)
+annotation class HiddenClass
+
+@HiddenClass
+@Target(AnnotationTarget.FUNCTION)
+annotation class HiddenFunction
+
+@HiddenClass
+@Target(AnnotationTarget.CONSTRUCTOR)
+annotation class HiddenCtor
+
+@HiddenClass
+@Target(AnnotationTarget.PROPERTY)
+annotation class HiddenProperty
+
+@HiddenClass
+@Target(AnnotationTarget.FIELD)
+annotation class HiddenField
+
+@HiddenClass
+@Target(AnnotationTarget.PROPERTY_GETTER)
+annotation class HiddenGetter
+
+@HiddenClass
+@Target(AnnotationTarget.PROPERTY_SETTER)
+annotation class HiddenSetter

--- a/src/functionalTest/resources/examples/classes/Properties.klib.dump
+++ b/src/functionalTest/resources/examples/classes/Properties.klib.dump
@@ -1,0 +1,15 @@
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <testproject>
+final class foo/ClassWithProperties { // foo/ClassWithProperties|null[0]
+    constructor <init>() // foo/ClassWithProperties.<init>|<init>(){}[0]
+}
+open annotation class foo/HiddenField : kotlin/Annotation { // foo/HiddenField|null[0]
+    constructor <init>() // foo/HiddenField.<init>|<init>(){}[0]
+}
+open annotation class foo/HiddenProperty : kotlin/Annotation { // foo/HiddenProperty|null[0]
+    constructor <init>() // foo/HiddenProperty.<init>|<init>(){}[0]
+}

--- a/src/functionalTest/resources/examples/classes/SubPackage.kt
+++ b/src/functionalTest/resources/examples/classes/SubPackage.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package com.company.division
+
+public class ClassWithinSubPackage {
+}
+

--- a/src/functionalTest/resources/examples/classes/Subclasses.dump
+++ b/src/functionalTest/resources/examples/classes/Subclasses.dump
@@ -1,0 +1,7 @@
+public final class subclasses/A {
+	public fun <init> ()V
+}
+
+public final class subclasses/A$D {
+	public fun <init> ()V
+}

--- a/src/functionalTest/resources/examples/classes/Subclasses.klib.dump
+++ b/src/functionalTest/resources/examples/classes/Subclasses.klib.dump
@@ -1,0 +1,12 @@
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <testproject>
+final class subclasses/A { // subclasses/A|null[0]
+    constructor <init>() // subclasses/A.<init>|<init>(){}[0]
+    final class D { // subclasses/A.D|null[0]
+        constructor <init>() // subclasses/A.D.<init>|<init>(){}[0]
+    }
+}

--- a/src/functionalTest/resources/examples/classes/Subclasses.kt
+++ b/src/functionalTest/resources/examples/classes/Subclasses.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package subclasses
+
+public class A {
+    public class B {
+        public class C
+    }
+
+    public class D {
+
+    }
+}

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.dump
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.dump
@@ -1,0 +1,65 @@
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <testproject>
+open annotation class examples.classes/A : kotlin/Annotation { // examples.classes/A|null[0]
+    constructor <init>() // examples.classes/A.<init>|<init>(){}[0]
+}
+abstract class examples.classes/AC { // examples.classes/AC|null[0]
+    constructor <init>() // examples.classes/AC.<init>|<init>(){}[0]
+    abstract fun a() // examples.classes/AC.a|a(){}[0]
+    final fun b() // examples.classes/AC.b|b(){}[0]
+}
+final class examples.classes/C { // examples.classes/C|null[0]
+    final val v // examples.classes/C.v|{}v[0]
+        final fun <get-v>(): kotlin/Any // examples.classes/C.v.<get-v>|<get-v>(){}[0]
+    constructor <init>(kotlin/Any) // examples.classes/C.<init>|<init>(kotlin.Any){}[0]
+    final fun m() // examples.classes/C.m|m(){}[0]
+}
+final class examples.classes/D { // examples.classes/D|null[0]
+    final val x // examples.classes/D.x|{}x[0]
+        final fun <get-x>(): kotlin/Int // examples.classes/D.x.<get-x>|<get-x>(){}[0]
+    constructor <init>(kotlin/Int) // examples.classes/D.<init>|<init>(kotlin.Int){}[0]
+    final fun component1(): kotlin/Int // examples.classes/D.component1|component1(){}[0]
+    final fun copy(kotlin/Int =...): examples.classes/D // examples.classes/D.copy|copy(kotlin.Int){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // examples.classes/D.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // examples.classes/D.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // examples.classes/D.toString|toString(){}[0]
+}
+final enum class examples.classes/E : kotlin/Enum<examples.classes/E> { // examples.classes/E|null[0]
+    final val entries // examples.classes/E.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/E> // examples.classes/E.entries.<get-entries>|<get-entries>#static(){}[0]
+    final fun valueOf(kotlin/String): examples.classes/E // examples.classes/E.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<examples.classes/E> // examples.classes/E.values|values#static(){}[0]
+    enum entry A // examples.classes/E.A|null[0]
+    enum entry B // examples.classes/E.B|null[0]
+    enum entry C // examples.classes/E.C|null[0]
+}
+abstract interface examples.classes/I // examples.classes/I|null[0]
+final object examples.classes/O // examples.classes/O|null[0]
+open class examples.classes/OC { // examples.classes/OC|null[0]
+    constructor <init>() // examples.classes/OC.<init>|<init>(){}[0]
+    final fun c() // examples.classes/OC.c|c(){}[0]
+    open fun o(): kotlin/Int // examples.classes/OC.o|o(){}[0]
+}
+final class examples.classes/Outer { // examples.classes/Outer|null[0]
+    constructor <init>() // examples.classes/Outer.<init>|<init>(){}[0]
+    final class Nested { // examples.classes/Outer.Nested|null[0]
+        constructor <init>() // examples.classes/Outer.Nested.<init>|<init>(){}[0]
+        final inner class Inner { // examples.classes/Outer.Nested.Inner|null[0]
+            constructor <init>() // examples.classes/Outer.Nested.Inner.<init>|<init>(){}[0]
+        }
+    }
+}
+final const val examples.classes/con // examples.classes/con|{}con[0]
+    final fun <get-con>(): kotlin/String // examples.classes/con.<get-con>|<get-con>(){}[0]
+final val examples.classes/l // examples.classes/l|{}l[0]
+    final fun <get-l>(): kotlin/Long // examples.classes/l.<get-l>|<get-l>(){}[0]
+final var examples.classes/r // examples.classes/r|{}r[0]
+    final fun <get-r>(): kotlin/Float // examples.classes/r.<get-r>|<get-r>(){}[0]
+    final fun <set-r>(kotlin/Float) // examples.classes/r.<set-r>|<set-r>(kotlin.Float){}[0]
+final fun <#A: kotlin/Any?> examples.classes/consume(#A) // examples.classes/consume|consume(0:0){0§<kotlin.Any?>}[0]
+final fun examples.classes/testFun(): kotlin/Int // examples.classes/testFun|testFun(){}[0]
+final inline fun examples.classes/testInlineFun() // examples.classes/testInlineFun|testInlineFun(){}[0]

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.v1.dump
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.v1.dump
@@ -1,0 +1,65 @@
+// Rendering settings:
+// - Signature version: 1
+// - Show manifest properties: false
+// - Show declarations: true
+
+// Library unique name: <testproject>
+open annotation class examples.classes/A : kotlin/Annotation { // examples.classes/A|null[0]
+    constructor <init>() // examples.classes/A.<init>|-5645683436151566731[0]
+}
+abstract class examples.classes/AC { // examples.classes/AC|null[0]
+    constructor <init>() // examples.classes/AC.<init>|-5645683436151566731[0]
+    abstract fun a() // examples.classes/AC.a|-4432112437378250461[0]
+    final fun b() // examples.classes/AC.b|4789657038926421504[0]
+}
+final class examples.classes/C { // examples.classes/C|null[0]
+    final val v // examples.classes/C.v|138869847852828796[0]
+        final fun <get-v>(): kotlin/Any // examples.classes/C.v.<get-v>|4964732996156868941[0]
+    constructor <init>(kotlin/Any) // examples.classes/C.<init>|4518179880532599055[0]
+    final fun m() // examples.classes/C.m|-1029306787563722981[0]
+}
+final class examples.classes/D { // examples.classes/D|null[0]
+    final val x // examples.classes/D.x|-8060530855978347579[0]
+        final fun <get-x>(): kotlin/Int // examples.classes/D.x.<get-x>|1482705010654679335[0]
+    constructor <init>(kotlin/Int) // examples.classes/D.<init>|-5182794243525578284[0]
+    final fun component1(): kotlin/Int // examples.classes/D.component1|162597135895221648[0]
+    final fun copy(kotlin/Int =...): examples.classes/D // examples.classes/D.copy|-6971662324481626298[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // examples.classes/D.equals|4638265728071529943[0]
+    final fun hashCode(): kotlin/Int // examples.classes/D.hashCode|3409210261493131192[0]
+    final fun toString(): kotlin/String // examples.classes/D.toString|-1522858123163872138[0]
+}
+final enum class examples.classes/E : kotlin/Enum<examples.classes/E> { // examples.classes/E|null[0]
+    final val entries // examples.classes/E.entries|-5134227801081826149[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/E> // examples.classes/E.entries.<get-entries>|-6068527377476727729[0]
+    final fun valueOf(kotlin/String): examples.classes/E // examples.classes/E.valueOf|-4683474617854611729[0]
+    final fun values(): kotlin/Array<examples.classes/E> // examples.classes/E.values|-8715569000920726747[0]
+    enum entry A // examples.classes/E.A|null[0]
+    enum entry B // examples.classes/E.B|null[0]
+    enum entry C // examples.classes/E.C|null[0]
+}
+abstract interface examples.classes/I // examples.classes/I|null[0]
+final object examples.classes/O // examples.classes/O|null[0]
+open class examples.classes/OC { // examples.classes/OC|null[0]
+    constructor <init>() // examples.classes/OC.<init>|-5645683436151566731[0]
+    final fun c() // examples.classes/OC.c|-2724918380551733646[0]
+    open fun o(): kotlin/Int // examples.classes/OC.o|-3264635847192431671[0]
+}
+final class examples.classes/Outer { // examples.classes/Outer|null[0]
+    constructor <init>() // examples.classes/Outer.<init>|-5645683436151566731[0]
+    final class Nested { // examples.classes/Outer.Nested|null[0]
+        constructor <init>() // examples.classes/Outer.Nested.<init>|-5645683436151566731[0]
+        final inner class Inner { // examples.classes/Outer.Nested.Inner|null[0]
+            constructor <init>() // examples.classes/Outer.Nested.Inner.<init>|-5645683436151566731[0]
+        }
+    }
+}
+final const val examples.classes/con // examples.classes/con|-2899158152154217071[0]
+    final fun <get-con>(): kotlin/String // examples.classes/con.<get-con>|-2604863570302238407[0]
+final val examples.classes/l // examples.classes/l|3307215303229595169[0]
+    final fun <get-l>(): kotlin/Long // examples.classes/l.<get-l>|3795442967620585[0]
+final var examples.classes/r // examples.classes/r|-8117627916896159533[0]
+    final fun <get-r>(): kotlin/Float // examples.classes/r.<get-r>|-7424184448774736572[0]
+    final fun <set-r>(kotlin/Float) // examples.classes/r.<set-r>|9171637170963327464[0]
+final fun <#A: kotlin/Any?> examples.classes/consume(#A) // examples.classes/consume|8042761629495509481[0]
+final fun examples.classes/testFun(): kotlin/Int // examples.classes/testFun|6322333980269160703[0]
+final inline fun examples.classes/testInlineFun() // examples.classes/testInlineFun|-9193388292326484960[0]

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.kt
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package examples.classes
+
+public fun testFun(): Int = 42
+public fun <T> consume(arg: T) = Unit
+public inline fun testInlineFun() = Unit
+public const val con: String = "I'm a constant!"
+public val l: Long = 0xc001
+public var r: Float = 3.14f
+
+public annotation class A
+public interface I
+public data class D(val x: Int)
+public class C(public val v: Any) {
+    public fun m() = Unit
+}
+
+public object O
+public enum class E { A, B, C }
+public abstract class AC {
+    public abstract fun a()
+    public fun b() = Unit
+}
+public open class OC {
+    public open fun o(): Int = 42
+    public fun c() = Unit
+}
+public class Outer {
+    public class Nested {
+        public inner class Inner {
+
+        }
+    }
+}

--- a/src/functionalTest/resources/examples/gradle/base/enableJvmInWithNativePlugin.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/enableJvmInWithNativePlugin.gradle.kts
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+kotlin {
+    jvm {
+    }
+}

--- a/src/functionalTest/resources/examples/gradle/base/withNativePlugin.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/withNativePlugin.gradle.kts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+plugins {
+    kotlin("multiplatform") version "1.9.10"
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    linuxX64()
+    linuxArm64()
+
+    mingwX64()
+
+    macosX64()
+    macosArm64()
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    tvosX64()
+    tvosArm64()
+    tvosSimulatorArm64()
+
+    watchosArm32()
+    watchosArm64()
+    watchosX64()
+    watchosSimulatorArm64()
+    watchosDeviceArm64()
+
+    androidNativeArm32()
+    androidNativeArm64()
+    androidNativeX64()
+    androidNativeX86()
+
+    sourceSets {
+        val commonMain by getting
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("stdlib"))
+                implementation(kotlin("test-common"))
+                implementation(kotlin("test-annotations-common"))
+            }
+        }
+    }
+
+}

--- a/src/functionalTest/resources/examples/gradle/base/withNativePlugin.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/withNativePlugin.gradle.kts
@@ -50,5 +50,8 @@ kotlin {
             }
         }
     }
+}
 
+apiValidation {
+    klibValidationEnabled = true
 }

--- a/src/functionalTest/resources/examples/gradle/configuration/ignoreSubclasses/ignore.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/ignoreSubclasses/ignore.gradle.kts
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    ignoredClasses.add("subclasses.A.B")
+    //ignoredClasses.add("subclasses.A\$B")
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/nonPublicMarkers/klib.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/nonPublicMarkers/klib.gradle.kts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    nonPublicMarkers.add("annotations.HiddenClass")
+    nonPublicMarkers.add("annotations.HiddenCtor")
+    nonPublicMarkers.add("annotations.HiddenProperty")
+    nonPublicMarkers.add("annotations.HiddenGetter")
+    nonPublicMarkers.add("annotations.HiddenSetter")
+    nonPublicMarkers.add("annotations.HiddenFunction")
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/signatures/invalid.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/signatures/invalid.gradle.kts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    klibSignatureVersion = 100500
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/signatures/v1.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/signatures/v1.gradle.kts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    klibSignatureVersion = 1
+}

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -13,6 +13,11 @@ open class ApiValidationExtension {
     public var validationDisabled = false
 
     /**
+     * Enables KLIB ABI validation checks completely.
+     */
+    public var klibValidationEnabled = false
+
+    /**
      * Fully qualified package names that are not consider public API.
      * For example, it could be `kotlinx.coroutines.internal` or `kotlinx.serialization.implementation`.
      */
@@ -64,4 +69,9 @@ open class ApiValidationExtension {
      * By default, only the `main` source set is checked.
      */
     public var additionalSourceSets: MutableSet<String> = HashSet()
+
+    /**
+     * Specify which version of signature KLIB ABI dump should contain.
+     */
+    public var klibSignatureVersion: Int = 2
 }

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -79,12 +79,9 @@ class BinaryCompatibilityValidatorPlugin : Plugin<Project> {
                 )
             }
         }
-        val nativeTargetProvider = project.provider {
-            kotlin.targets.count { it.platformType == KotlinPlatformType.native }
-        }
 
         val dirConfig = jvmTargetCountProvider.map {
-            if (it == 1 && nativeTargetProvider.get() == 0) DirConfig.COMMON else DirConfig.TARGET_DIR
+            if (it == 1 && !extension.klibValidationEnabled) DirConfig.COMMON else DirConfig.TARGET_DIR
         }
         val nativeDirConfig = project.provider { DirConfig.NATIVE_TARGET_DIR }
 
@@ -184,6 +181,8 @@ private enum class DirConfig {
      * `/api/jvm/project.api` and `/api/android/project.api`
      */
     TARGET_DIR,
+    // TODO
+    // Currently, has the same meaning as TARGET_DIR
     NATIVE_TARGET_DIR
 }
 

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -11,6 +11,8 @@ import org.gradle.api.provider.*
 import org.gradle.api.tasks.*
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.plugin.*
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.konan.target.HostManager
 import java.io.*
 
 const val API_DIR = "api"
@@ -106,9 +108,12 @@ class BinaryCompatibilityValidatorPlugin : Plugin<Project> {
             }
         }
         kotlin.targets.matching { it.platformType == KotlinPlatformType.native }.all { target ->
-            val targetConfig = TargetConfig(project, target.name, nativeDirConfig)
-            target.compilations.matching { it.name == "main" }.all {
-                project.configureNativeCompilation(it, extension, targetConfig, commonApiDump, commonApiCheck)
+            target as KotlinNativeTarget
+            if (HostManager().isEnabled(target.konanTarget)) {
+                val targetConfig = TargetConfig(project, target.name, nativeDirConfig)
+                target.compilations.matching { it.name == "main" }.all {
+                    project.configureNativeCompilation(it, extension, targetConfig, commonApiDump, commonApiCheck)
+                }
             }
         }
     }

--- a/src/main/kotlin/BuildTaskBase.kt
+++ b/src/main/kotlin/BuildTaskBase.kt
@@ -12,7 +12,7 @@ import org.gradle.api.tasks.OutputDirectory
 import java.io.File
 
 abstract class BuildTaskBase : DefaultTask() {
-    protected val extension = project.apiValidationExtensionOrNull
+    private val extension = project.apiValidationExtensionOrNull
 
     @OutputDirectory
     lateinit var outputApiDir: File

--- a/src/main/kotlin/BuildTaskBase.kt
+++ b/src/main/kotlin/BuildTaskBase.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import java.io.File
+
+abstract class BuildTaskBase : DefaultTask() {
+    protected val extension = project.apiValidationExtensionOrNull
+
+    @OutputDirectory
+    lateinit var outputApiDir: File
+
+    private var _ignoredPackages: Set<String>? = null
+    @get:Input
+    var ignoredPackages : Set<String>
+        get() = _ignoredPackages ?: extension?.ignoredPackages ?: emptySet()
+        set(value) { _ignoredPackages = value }
+
+    private var _nonPublicMarkes: Set<String>? = null
+    @get:Input
+    var nonPublicMarkers : Set<String>
+        get() = _nonPublicMarkes ?: extension?.nonPublicMarkers ?: emptySet()
+        set(value) { _nonPublicMarkes = value }
+
+    private var _ignoredClasses: Set<String>? = null
+    @get:Input
+    var ignoredClasses : Set<String>
+        get() = _ignoredClasses ?: extension?.ignoredClasses ?: emptySet()
+        set(value) { _ignoredClasses = value }
+
+    private var _publicPackages: Set<String>? = null
+    @get:Input
+    var publicPackages: Set<String>
+        get() = _publicPackages ?: extension?.publicPackages ?: emptySet()
+        set(value) { _publicPackages = value }
+
+    private var _publicMarkers: Set<String>? = null
+    @get:Input
+    var publicMarkers: Set<String>
+        get() = _publicMarkers ?: extension?.publicMarkers ?: emptySet()
+        set(value) { _publicMarkers = value}
+
+    private var _publicClasses: Set<String>? = null
+    @get:Input
+    var publicClasses: Set<String>
+        get() = _publicClasses ?: extension?.publicClasses ?: emptySet()
+        set(value) { _publicClasses = value }
+
+    @get:Internal
+    internal val projectName = project.name
+}

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -14,9 +14,7 @@ import java.util.jar.JarFile
 import javax.inject.Inject
 
 open class KotlinApiBuildTask @Inject constructor(
-) : DefaultTask() {
-
-    private val extension = project.apiValidationExtensionOrNull
+) : BuildTaskBase() {
 
     @InputFiles
     @Optional
@@ -31,48 +29,6 @@ open class KotlinApiBuildTask @Inject constructor(
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
     lateinit var inputDependencies: FileCollection
-
-    @OutputDirectory
-    lateinit var outputApiDir: File
-
-    private var _ignoredPackages: Set<String>? = null
-    @get:Input
-    var ignoredPackages : Set<String>
-        get() = _ignoredPackages ?: extension?.ignoredPackages ?: emptySet()
-        set(value) { _ignoredPackages = value }
-
-    private var _nonPublicMarkes: Set<String>? = null
-    @get:Input
-    var nonPublicMarkers : Set<String>
-        get() = _nonPublicMarkes ?: extension?.nonPublicMarkers ?: emptySet()
-        set(value) { _nonPublicMarkes = value }
-
-    private var _ignoredClasses: Set<String>? = null
-    @get:Input
-    var ignoredClasses : Set<String>
-        get() = _ignoredClasses ?: extension?.ignoredClasses ?: emptySet()
-        set(value) { _ignoredClasses = value }
-
-    private var _publicPackages: Set<String>? = null
-    @get:Input
-    var publicPackages: Set<String>
-        get() = _publicPackages ?: extension?.publicPackages ?: emptySet()
-        set(value) { _publicPackages = value }
-
-    private var _publicMarkers: Set<String>? = null
-    @get:Input
-    var publicMarkers: Set<String>
-        get() = _publicMarkers ?: extension?.publicMarkers ?: emptySet()
-        set(value) { _publicMarkers = value}
-
-    private var _publicClasses: Set<String>? = null
-    @get:Input
-    var publicClasses: Set<String>
-        get() = _publicClasses ?: extension?.publicClasses ?: emptySet()
-        set(value) { _publicClasses = value }
-
-    @get:Internal
-    internal val projectName = project.name
 
     @TaskAction
     fun generate() {

--- a/src/main/kotlin/KotlinKlibAbiBuildTask.kt
+++ b/src/main/kotlin/KotlinKlibAbiBuildTask.kt
@@ -12,9 +12,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.library.abi.*
 
-abstract class KotlinKlibAbiBuildTask constructor(
-
-) : BuildTaskBase() {
+abstract class KotlinKlibAbiBuildTask : BuildTaskBase() {
 
     @get:InputFiles
     abstract val klibFile: ConfigurableFileCollection
@@ -55,8 +53,10 @@ abstract class KotlinKlibAbiBuildTask constructor(
         val sigVersion = if (signatureVersion != null) {
             val versionNumbers = supportedVersions.map { it.versionNumber }.toSortedSet()
             if (signatureVersion !in versionNumbers) {
-                throw IllegalArgumentException("Unsupported signature version '$signatureVersion'. " +
-                        "Supported versions are: $versionNumbers")
+                throw IllegalArgumentException(
+                    "Unsupported signature version '$signatureVersion'. " +
+                            "Supported versions are: $versionNumbers"
+                )
             }
             AbiSignatureVersion.resolveByVersionNumber(signatureVersion!!)
         } else {
@@ -72,7 +72,7 @@ abstract class KotlinKlibAbiBuildTask constructor(
 
 @ExperimentalStdlibApi
 @ExperimentalLibraryAbiReader
-internal fun generateQualifiedNames(name: String) : List<AbiQualifiedName> {
+internal fun generateQualifiedNames(name: String): List<AbiQualifiedName> {
     if (!name.contains('.')) {
         return listOf(AbiQualifiedName(AbiCompoundName(""), AbiCompoundName(name)))
     }

--- a/src/main/kotlin/KotlinKlibAbiBuildTask.kt
+++ b/src/main/kotlin/KotlinKlibAbiBuildTask.kt
@@ -37,12 +37,15 @@ abstract class KotlinKlibAbiBuildTask constructor(
             }
             if (ignoredClasses.isNotEmpty()) {
                 add(AbiReadingFilter.ExcludedClasses(ignoredClasses.flatMap {
-                    generateQualifiedName(it)
+                    generateQualifiedNames(it)
                 }))
             }
             if (nonPublicMarkers.isNotEmpty()) {
+                println(nonPublicMarkers.flatMap {
+                    generateQualifiedNames(it)
+                })
                 add(AbiReadingFilter.NonPublicMarkerAnnotations(nonPublicMarkers.flatMap {
-                    generateQualifiedName(it)
+                    generateQualifiedNames(it)
                 }))
             }
         }
@@ -62,20 +65,20 @@ abstract class KotlinKlibAbiBuildTask constructor(
             LibraryAbiRenderer.render(parsedAbi, it, AbiRenderingSettings(sigVersion))
         }
     }
+}
 
-    @ExperimentalStdlibApi
-    @ExperimentalLibraryAbiReader
-    private fun generateQualifiedName(name: String) : List<AbiQualifiedName> {
-        if (!name.contains('.')) {
-            return listOf(AbiQualifiedName(AbiCompoundName(""), AbiCompoundName(name)))
-        }
-        val parts = name.split('.')
-        return buildList {
-            for (packageLength in 0 until parts.size - 1) {
-                val packageName = AbiCompoundName(parts.subList(0, packageLength).joinToString("."))
-                val className = AbiCompoundName(parts.subList(packageLength, parts.size).joinToString("."))
-                add(AbiQualifiedName(packageName, className))
-            }
+@ExperimentalStdlibApi
+@ExperimentalLibraryAbiReader
+internal fun generateQualifiedNames(name: String) : List<AbiQualifiedName> {
+    if (!name.contains('.')) {
+        return listOf(AbiQualifiedName(AbiCompoundName(""), AbiCompoundName(name)))
+    }
+    val parts = name.split('.')
+    return buildList {
+        for (packageLength in parts.indices) {
+            val packageName = AbiCompoundName(parts.subList(0, packageLength).joinToString("."))
+            val className = AbiCompoundName(parts.subList(packageLength, parts.size).joinToString("."))
+            add(AbiQualifiedName(packageName, className))
         }
     }
 }

--- a/src/main/kotlin/KotlinKlibAbiBuildTask.kt
+++ b/src/main/kotlin/KotlinKlibAbiBuildTask.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.jetbrains.kotlin.library.abi.*
+import java.io.File
+
+abstract class KotlinKlibAbiBuildTask constructor(
+
+) : BuildTaskBase() {
+
+    @get:InputFiles
+    abstract val klibFile: ConfigurableFileCollection
+
+    // TODO: configure
+    @Optional
+    @get:Input
+    var signatureVersion: Int? = null
+
+    @ExperimentalStdlibApi
+    @ExperimentalLibraryAbiReader
+    @TaskAction
+    fun generate() {
+        outputApiDir.deleteRecursively()
+        outputApiDir.mkdirs()
+
+        val filters = buildList {
+            if (ignoredPackages.isNotEmpty()) {
+                add(AbiReadingFilter.ExcludedPackages(ignoredPackages.map { AbiCompoundName(it) }))
+            }
+            if (ignoredClasses.isNotEmpty()) {
+                add(AbiReadingFilter.ExcludedClasses(ignoredClasses.flatMap {
+                    generateQualifiedName(it)
+                }))
+            }
+            if (nonPublicMarkers.isNotEmpty()) {
+                add(AbiReadingFilter.NonPublicMarkerAnnotations(nonPublicMarkers.flatMap {
+                    generateQualifiedName(it)
+                }))
+            }
+        }
+
+        // Ooops, publicPackages, publicClasses and publicMarkers are not supported
+
+        val parsedAbi = LibraryAbiReader.readAbiInfo(klibFile.singleFile, filters)
+
+        val sigVersion = if (signatureVersion != null) {
+            AbiSignatureVersion.resolveByVersionNumber(signatureVersion!!)
+        } else {
+            parsedAbi.signatureVersions.maxByOrNull(AbiSignatureVersion::versionNumber)
+                ?: throw IllegalStateException("Can't choose abiSignatureVersion")
+        }
+
+        outputApiDir.resolve(project.name + ".api").bufferedWriter().use {
+            LibraryAbiRenderer.render(parsedAbi, it, AbiRenderingSettings(sigVersion))
+        }
+    }
+
+    @ExperimentalStdlibApi
+    @ExperimentalLibraryAbiReader
+    private fun generateQualifiedName(name: String) : List<AbiQualifiedName> {
+        if (!name.contains('.')) {
+            return listOf(AbiQualifiedName(AbiCompoundName(""), AbiCompoundName(name)))
+        }
+        val parts = name.split('.')
+        return buildList {
+            for (packageLength in 0 until parts.size - 1) {
+                val packageName = AbiCompoundName(parts.subList(0, packageLength).joinToString("."))
+                val className = AbiCompoundName(parts.subList(packageLength, parts.size).joinToString("."))
+                add(AbiQualifiedName(packageName, className))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/KotlinKlibAbiBuildTask.kt
+++ b/src/main/kotlin/KotlinKlibAbiBuildTask.kt
@@ -5,20 +5,12 @@
 
 package kotlinx.validation
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.FileCollection
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.library.abi.*
-import java.io.File
 
 abstract class KotlinKlibAbiBuildTask constructor(
 
@@ -66,7 +58,7 @@ abstract class KotlinKlibAbiBuildTask constructor(
                 ?: throw IllegalStateException("Can't choose abiSignatureVersion")
         }
 
-        outputApiDir.resolve(project.name + ".api").bufferedWriter().use {
+        outputApiDir.resolve("$projectName.api").bufferedWriter().use {
             LibraryAbiRenderer.render(parsedAbi, it, AbiRenderingSettings(sigVersion))
         }
     }

--- a/src/test/kotlin/tests/AbiTest.kt
+++ b/src/test/kotlin/tests/AbiTest.kt
@@ -27,4 +27,4 @@ class AbiTest {
             generateQualifiedNames("Class")
         )
     }
-Ъ
+}

--- a/src/test/kotlin/tests/AbiTest.kt
+++ b/src/test/kotlin/tests/AbiTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.api.tests
+
+import kotlinx.validation.generateQualifiedNames
+import org.jetbrains.kotlin.library.abi.*
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class AbiTest {
+    @OptIn(ExperimentalLibraryAbiReader::class, ExperimentalStdlibApi::class)
+    @Test
+    fun generateAbiNames() {
+        assertEquals(
+            listOf(
+                AbiQualifiedName(AbiCompoundName(""), AbiCompoundName("foo.bar.Baz")),
+                AbiQualifiedName(AbiCompoundName("foo"), AbiCompoundName("bar.Baz")),
+                AbiQualifiedName(AbiCompoundName("foo.bar"), AbiCompoundName("Baz"))
+            ),
+            generateQualifiedNames("foo.bar.Baz")
+        )
+        assertEquals(
+            listOf(AbiQualifiedName(AbiCompoundName(""), AbiCompoundName("Class"))),
+            generateQualifiedNames("Class")
+        )
+    }
+Ъ


### PR DESCRIPTION
Supported Klib ABI validation.

The validation is disabled by default and requires the following settings to be turned on:
```
apiValidation {
    klibValidationEnabled = true
}
```

KLib validation supports `ignoredPackages`, `ignoredClasses` and `nonPublicMarkers` options the same way classfiles validation does, but all `public*` options are unsupported and will be ignored.

As with the JVM API validation, ABI is dumped into a text file. There's a separate dump file for each native target, each located in a directory named after the target.
Here's an example of a file tree for kotlinx-io's core module:
```
kotlinx-io
    core
        api
            androidNativeArm32
                kotlinx-io-core.api
            androidNativeArm64
                kotlinx-io-core.api
...
            jvm
                kotlinx-io-core.api
...
            linuxArm64
                kotlinx-io-core.api
...
```

One of the disadvantages of such a scheme for storing dumps is that once something is changed in the common sourceset, api-files for all targets will reflect that change. It's an open question if some other scheme to represent the native ABI should be used.