### PR TITLE
Fix functional tests not utilizing the API_DIR const value

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
@@ -5,6 +5,7 @@
 
 package kotlinx.validation.api
 
+import kotlinx.validation.API_DIR
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import java.io.File
@@ -16,5 +17,5 @@ public open class BaseKotlinGradleTest {
 
     internal val rootProjectDir: File get() = testProjectDir.root
 
-    internal val rootProjectApiDump: File get() = rootProjectDir.resolve("api/${rootProjectDir.name}.api")
+    internal val rootProjectApiDump: File get() = rootProjectDir.resolve("$API_DIR/${rootProjectDir.name}.api")
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/DefaultConfigTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/DefaultConfigTests.kt
@@ -5,6 +5,7 @@
 
 package kotlinx.validation.test
 
+import kotlinx.validation.API_DIR
 import kotlinx.validation.api.*
 import org.assertj.core.api.*
 import org.junit.Test
@@ -183,7 +184,7 @@ internal class DefaultConfigTests : BaseKotlinGradleTest() {
         runner.build().apply {
             assertTaskSuccess(":apiDump")
 
-            val apiDumpFile = rootProjectDir.resolve("api/testproject.api")
+            val apiDumpFile = rootProjectDir.resolve("$API_DIR/testproject.api")
             assertTrue(apiDumpFile.exists(), "api dump file ${apiDumpFile.path} should exist")
 
             assertFalse(rootProjectApiDump.exists(), "api dump file ${rootProjectApiDump.path} should NOT exist " +

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultiPlatformSingleJvmTargetTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultiPlatformSingleJvmTargetTest.kt
@@ -5,6 +5,7 @@
 
 package kotlinx.validation.test
 
+import kotlinx.validation.API_DIR
 import kotlinx.validation.api.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -29,7 +30,7 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
                     arguments.add("--stacktrace")
                 }
 
-                dir("api/") {
+                dir("$API_DIR/") {
                     file("testproject.api") {
                         resolve("examples/classes/Subsub1Class.dump")
                         resolve("examples/classes/Subsub2Class.dump")
@@ -61,7 +62,7 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
                     arguments.add("--stacktrace")
                 }
 
-                dir("api/") {
+                dir("$API_DIR/") {
                     file("testproject.api") {
                         resolve("examples/classes/Subsub2Class.dump")
                         resolve("examples/classes/Subsub1Class.dump")
@@ -116,6 +117,6 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
         }
     }
 
-    private val jvmApiDump: File get() = rootProjectDir.resolve("api/testproject.api")
+    private val jvmApiDump: File get() = rootProjectDir.resolve("$API_DIR/testproject.api")
 
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
@@ -5,6 +5,7 @@
 
 package kotlinx.validation.test
 
+import kotlinx.validation.API_DIR
 import kotlinx.validation.api.*
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
@@ -30,14 +31,14 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
                 arguments.add(":apiCheck")
             }
 
-            dir("api/jvm/") {
+            dir("$API_DIR/jvm/") {
                 file("testproject.api") {
                     resolve("examples/classes/Subsub1Class.dump")
                     resolve("examples/classes/Subsub2Class.dump")
                 }
             }
 
-            dir("api/anotherJvm/") {
+            dir("$API_DIR/anotherJvm/") {
                 file("testproject.api") {
                     resolve("examples/classes/Subsub1Class.dump")
                 }
@@ -69,14 +70,14 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
                 arguments.add(":check")
             }
 
-            dir("api/jvm/") {
+            dir("$API_DIR/jvm/") {
                 file("testproject.api") {
                     resolve("examples/classes/Subsub2Class.dump")
                     resolve("examples/classes/Subsub1Class.dump")
                 }
             }
 
-            dir("api/anotherJvm/") {
+            dir("$API_DIR/anotherJvm/") {
                 file("testproject.api") {
                     resolve("examples/classes/Subsub2Class.dump")
                 }
@@ -134,7 +135,7 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
         }
     }
 
-    private val jvmApiDump: File get() = rootProjectDir.resolve("api/jvm/testproject.api")
-    private val anotherApiDump: File get() = rootProjectDir.resolve("api/anotherJvm/testproject.api")
+    private val jvmApiDump: File get() = rootProjectDir.resolve("$API_DIR/jvm/testproject.api")
+    private val anotherApiDump: File get() = rootProjectDir.resolve("$API_DIR/anotherJvm/testproject.api")
 
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnRootTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnRootTests.kt
@@ -5,6 +5,7 @@
 
 package kotlinx.validation.test
 
+import kotlinx.validation.API_DIR
 import kotlinx.validation.api.*
 import kotlinx.validation.api.BaseKotlinGradleTest
 import kotlinx.validation.api.assertTaskSuccess
@@ -258,7 +259,7 @@ internal class SubprojectsWithPluginOnRootTests : BaseKotlinGradleTest() {
         runner.build().apply {
             assertTaskSuccess(":sub1:apiDump")
 
-            val apiDumpFile = rootProjectDir.resolve("sub1/api/sub1.api")
+            val apiDumpFile = rootProjectDir.resolve("sub1/$API_DIR/sub1.api")
             assertTrue(apiDumpFile.exists(), "api dump file ${apiDumpFile.path} should exist")
 
             Assertions.assertThat(apiDumpFile.readText()).isEqualToIgnoringNewLines("")
@@ -298,21 +299,21 @@ internal class SubprojectsWithPluginOnRootTests : BaseKotlinGradleTest() {
             assertTrue(rootProjectApiDump.exists(), "api dump file ${rootProjectApiDump.path} should exist")
             Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines("")
 
-            val apiSub1 = rootProjectDir.resolve("sub1/api/sub1.api")
+            val apiSub1 = rootProjectDir.resolve("sub1/$API_DIR/sub1.api")
             assertTrue(apiSub1.exists(), "api dump file ${apiSub1.path} should exist")
             Assertions.assertThat(apiSub1.readText()).isEqualToIgnoringNewLines("")
 
-            val apiSubsub1 = rootProjectDir.resolve("sub1/subsub1/api/subsub1.api")
+            val apiSubsub1 = rootProjectDir.resolve("sub1/subsub1/$API_DIR/subsub1.api")
             assertTrue(apiSubsub1.exists(), "api dump file ${apiSubsub1.path} should exist")
             val apiSubsub1Expected = readFileList("examples/classes/Subsub1Class.dump")
             Assertions.assertThat(apiSubsub1.readText()).isEqualToIgnoringNewLines(apiSubsub1Expected)
 
-            val apiSubsub2 = rootProjectDir.resolve("sub1/subsub2/api/subsub2.api")
+            val apiSubsub2 = rootProjectDir.resolve("sub1/subsub2/$API_DIR/subsub2.api")
             assertTrue(apiSubsub2.exists(), "api dump file ${apiSubsub2.path} should exist")
             val apiSubsub2Expected = readFileList("examples/classes/Subsub2Class.dump")
             Assertions.assertThat(apiSubsub2.readText()).isEqualToIgnoringNewLines(apiSubsub2Expected)
 
-            val apiSub2 = rootProjectDir.resolve("sub2/api/sub2.api")
+            val apiSub2 = rootProjectDir.resolve("sub2/$API_DIR/sub2.api")
             assertTrue(apiSub2.exists(), "api dump file ${apiSub2.path} should exist")
             Assertions.assertThat(apiSub2.readText()).isEqualToIgnoringNewLines("")
         }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnSubTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnSubTests.kt
@@ -5,6 +5,7 @@
 
 package kotlinx.validation.test
 
+import kotlinx.validation.API_DIR
 import kotlinx.validation.api.*
 import kotlinx.validation.api.BaseKotlinGradleTest
 import kotlinx.validation.api.assertTaskSuccess
@@ -241,7 +242,7 @@ internal class SubprojectsWithPluginOnSubTests : BaseKotlinGradleTest() {
         runner.build().apply {
             assertTaskSuccess(":sub1:apiDump")
 
-            val apiDumpFile = rootProjectDir.resolve("sub1/api/sub1.api")
+            val apiDumpFile = rootProjectDir.resolve("sub1/$API_DIR/sub1.api")
             assertTrue(apiDumpFile.exists(), "api dump file ${apiDumpFile.path} should exist")
 
             Assertions.assertThat(apiDumpFile.readText()).isEqualToIgnoringNewLines("")
@@ -280,21 +281,21 @@ internal class SubprojectsWithPluginOnSubTests : BaseKotlinGradleTest() {
 
             assertFalse(rootProjectApiDump.exists(), "api dump file ${rootProjectApiDump.path} should NOT exist")
 
-            val apiSub1 = rootProjectDir.resolve("sub1/api/sub1.api")
+            val apiSub1 = rootProjectDir.resolve("sub1/$API_DIR/sub1.api")
             assertTrue(apiSub1.exists(), "api dump file ${apiSub1.path} should exist")
             Assertions.assertThat(apiSub1.readText()).isEqualToIgnoringNewLines("")
 
-            val apiSubsub1 = rootProjectDir.resolve("sub1/subsub1/api/subsub1.api")
+            val apiSubsub1 = rootProjectDir.resolve("sub1/subsub1/$API_DIR/subsub1.api")
             assertTrue(apiSubsub1.exists(), "api dump file ${apiSubsub1.path} should exist")
             val apiSubsub1Expected = readFileList("examples/classes/Subsub1Class.dump")
             Assertions.assertThat(apiSubsub1.readText()).isEqualToIgnoringNewLines(apiSubsub1Expected)
 
-            val apiSubsub2 = rootProjectDir.resolve("sub1/subsub2/api/subsub2.api")
+            val apiSubsub2 = rootProjectDir.resolve("sub1/subsub2/$API_DIR/subsub2.api")
             assertTrue(apiSubsub2.exists(), "api dump file ${apiSubsub2.path} should exist")
             val apiSubsub2Expected = readFileList("examples/classes/Subsub2Class.dump")
             Assertions.assertThat(apiSubsub2.readText()).isEqualToIgnoringNewLines(apiSubsub2Expected)
 
-            val apiSub2 = rootProjectDir.resolve("sub2/api/sub2.api")
+            val apiSub2 = rootProjectDir.resolve("sub2/$API_DIR/sub2.api")
             assertFalse(apiSub2.exists(), "api dump file ${apiSub2.path} should NOT exist")
         }
     }


### PR DESCRIPTION
This PR just fixes the hardcoding of the `api` directory in the project's tests.