### PR TITLE
Do not depend on sources and javadocs twice during the publication pr…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,8 +113,6 @@ publishing {
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])
-            artifact(tasks.javadocJar)
-            artifact(tasks.sourcesJar)
         }
 
         mavenRepositoryPublishing(project)


### PR DESCRIPTION
…ocess

* 'java { withXJar }' already provides a dependency

Fixes 'Invalid publication 'maven': multiple artifacts with the identical extension and classifier ('jar', 'javadoc')' failure during publication process