### PR TITLE
Enable strict explicit API mode

### DIFF
--- a/api/binary-compatibility-validator.api
+++ b/api/binary-compatibility-validator.api
@@ -26,11 +26,6 @@ public final class kotlinx/validation/BinaryCompatibilityValidatorPlugin : org/g
 	public fun apply (Lorg/gradle/api/Project;)V
 }
 
-public final class kotlinx/validation/BinaryCompatibilityValidatorPluginKt {
-	public static final field API_DIR Ljava/lang/String;
-	public static final fun apiCheckEnabled (Ljava/lang/String;Lkotlinx/validation/ApiValidationExtension;)Z
-}
-
 public abstract interface annotation class kotlinx/validation/ExternalApi : java/lang/annotation/Annotation {
 }
 
@@ -38,32 +33,18 @@ public class kotlinx/validation/KotlinApiBuildTask : org/gradle/api/DefaultTask 
 	public field inputDependencies Lorg/gradle/api/file/FileCollection;
 	public field outputApiDir Ljava/io/File;
 	public fun <init> ()V
-	public final fun generate ()V
-	public final fun getIgnoredClasses ()Ljava/util/Set;
-	public final fun getIgnoredPackages ()Ljava/util/Set;
 	public final fun getInputClassesDirs ()Lorg/gradle/api/file/FileCollection;
 	public final fun getInputDependencies ()Lorg/gradle/api/file/FileCollection;
 	public final fun getInputJar ()Lorg/gradle/api/file/RegularFileProperty;
-	public final fun getNonPublicMarkers ()Ljava/util/Set;
 	public final fun getOutputApiDir ()Ljava/io/File;
-	public final fun getPublicClasses ()Ljava/util/Set;
-	public final fun getPublicMarkers ()Ljava/util/Set;
-	public final fun getPublicPackages ()Ljava/util/Set;
-	public final fun setIgnoredClasses (Ljava/util/Set;)V
-	public final fun setIgnoredPackages (Ljava/util/Set;)V
 	public final fun setInputClassesDirs (Lorg/gradle/api/file/FileCollection;)V
 	public final fun setInputDependencies (Lorg/gradle/api/file/FileCollection;)V
-	public final fun setNonPublicMarkers (Ljava/util/Set;)V
 	public final fun setOutputApiDir (Ljava/io/File;)V
-	public final fun setPublicClasses (Ljava/util/Set;)V
-	public final fun setPublicMarkers (Ljava/util/Set;)V
-	public final fun setPublicPackages (Ljava/util/Set;)V
 }
 
 public class kotlinx/validation/KotlinApiCompareTask : org/gradle/api/DefaultTask {
 	public field apiBuildDir Ljava/io/File;
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
-	public final fun compareApiDumps (Ljava/io/File;Ljava/io/File;)V
 	public final fun getApiBuildDir ()Ljava/io/File;
 	public final fun getDummyOutputFile ()Ljava/io/File;
 	public final fun getNonExistingProjectApiDir ()Ljava/lang/String;
@@ -71,137 +52,14 @@ public class kotlinx/validation/KotlinApiCompareTask : org/gradle/api/DefaultTas
 	public final fun setApiBuildDir (Ljava/io/File;)V
 	public final fun setNonExistingProjectApiDir (Ljava/lang/String;)V
 	public final fun setProjectApiDir (Ljava/io/File;)V
-	public final fun verify ()V
-}
-
-public final class kotlinx/validation/api/AccessFlags {
-	public fun <init> (I)V
-	public final fun component1 ()I
-	public final fun copy (I)Lkotlinx/validation/api/AccessFlags;
-	public static synthetic fun copy$default (Lkotlinx/validation/api/AccessFlags;IILjava/lang/Object;)Lkotlinx/validation/api/AccessFlags;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAccess ()I
-	public final fun getModifierString ()Ljava/lang/String;
-	public final fun getModifiers ()Ljava/util/List;
-	public fun hashCode ()I
-	public final fun isFinal ()Z
-	public final fun isProtected ()Z
-	public final fun isPublic ()Z
-	public final fun isStatic ()Z
-	public final fun isSynthetic ()Z
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class kotlinx/validation/api/AsmMetadataLoadingKt {
-	public static final field publishedApiAnnotationName Ljava/lang/String;
-	public static final fun findAnnotation (Lorg/objectweb/asm/tree/ClassNode;Ljava/lang/String;Z)Lorg/objectweb/asm/tree/AnnotationNode;
-	public static synthetic fun findAnnotation$default (Lorg/objectweb/asm/tree/ClassNode;Ljava/lang/String;ZILjava/lang/Object;)Lorg/objectweb/asm/tree/AnnotationNode;
-	public static final fun get (Lorg/objectweb/asm/tree/AnnotationNode;Ljava/lang/String;)Ljava/lang/Object;
-	public static final fun getACCESS_NAMES ()Ljava/util/Map;
-	public static final fun getEffectiveAccess (Lorg/objectweb/asm/tree/ClassNode;)I
-	public static final fun getInnerClassNode (Lorg/objectweb/asm/tree/ClassNode;)Lorg/objectweb/asm/tree/InnerClassNode;
-	public static final fun getOuterClassName (Lorg/objectweb/asm/tree/ClassNode;)Ljava/lang/String;
-	public static final fun isDefaultImpls (Lorg/objectweb/asm/tree/ClassNode;Lkotlinx/metadata/jvm/KotlinClassMetadata;)Z
-	public static final fun isEffectivelyPublic (Lorg/objectweb/asm/tree/ClassNode;Lkotlinx/validation/api/ClassVisibility;)Z
-	public static final fun isEnumEntriesMappings (Lorg/objectweb/asm/tree/ClassNode;)Z
-	public static final fun isFinal (I)Z
-	public static final fun isInner (Lorg/objectweb/asm/tree/ClassNode;)Z
-	public static final fun isLocal (Lorg/objectweb/asm/tree/ClassNode;)Z
-	public static final fun isProtected (I)Z
-	public static final fun isPublic (I)Z
-	public static final fun isPublishedApi (Ljava/util/List;)Z
-	public static final fun isPublishedApi (Lorg/objectweb/asm/tree/ClassNode;)Z
-	public static final fun isStatic (I)Z
-	public static final fun isSynthetic (I)Z
-	public static final fun isSyntheticAnnotationClass (Lorg/objectweb/asm/tree/ClassNode;)Z
-	public static final fun isWhenMappings (Lorg/objectweb/asm/tree/ClassNode;)Z
-	public static final fun refersToName (Lorg/objectweb/asm/tree/AnnotationNode;Ljava/lang/String;)Z
 }
 
 public final class kotlinx/validation/api/ClassBinarySignature {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/validation/api/AccessFlags;ZZLjava/util/List;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/util/List;
-	public final fun component5 ()Ljava/util/List;
-	public final fun component6 ()Lkotlinx/validation/api/AccessFlags;
-	public final fun component7 ()Z
-	public final fun component8 ()Z
-	public final fun component9 ()Ljava/util/List;
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/validation/api/AccessFlags;ZZLjava/util/List;)Lkotlinx/validation/api/ClassBinarySignature;
 	public static synthetic fun copy$default (Lkotlinx/validation/api/ClassBinarySignature;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/validation/api/AccessFlags;ZZLjava/util/List;ILjava/lang/Object;)Lkotlinx/validation/api/ClassBinarySignature;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAccess ()Lkotlinx/validation/api/AccessFlags;
-	public final fun getAnnotations ()Ljava/util/List;
-	public final fun getMemberSignatures ()Ljava/util/List;
-	public final fun getName ()Ljava/lang/String;
-	public final fun getOuterName ()Ljava/lang/String;
-	public final fun getSignature ()Ljava/lang/String;
-	public final fun getSuperName ()Ljava/lang/String;
-	public final fun getSupertypes ()Ljava/util/List;
 	public fun hashCode ()I
-	public final fun isEffectivelyPublic ()Z
-	public final fun isNotUsedWhenEmpty ()Z
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class kotlinx/validation/api/ClassVisibility {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getCompanionVisibilities ()Lkotlinx/validation/api/ClassVisibility;
-	public final fun getFacadeClassName ()Ljava/lang/String;
-	public final fun getFlags ()Ljava/lang/Integer;
-	public final fun getMembers ()Ljava/util/Map;
-	public final fun getName ()Ljava/lang/String;
-	public final fun getPartVisibilities ()Ljava/util/List;
-	public final fun getVisibility ()Ljava/lang/Integer;
-	public final fun isCompanion ()Z
-	public final fun setCompanionVisibilities (Lkotlinx/validation/api/ClassVisibility;)V
-}
-
-public final class kotlinx/validation/api/FieldBinarySignature : kotlinx/validation/api/MemberBinarySignature {
-	public fun <init> (Lkotlinx/metadata/jvm/JvmFieldSignature;ZLkotlinx/validation/api/AccessFlags;Ljava/util/List;)V
-	public final fun component1 ()Lkotlinx/metadata/jvm/JvmFieldSignature;
-	public final fun component2 ()Z
-	public final fun component3 ()Lkotlinx/validation/api/AccessFlags;
-	public final fun component4 ()Ljava/util/List;
-	public final fun copy (Lkotlinx/metadata/jvm/JvmFieldSignature;ZLkotlinx/validation/api/AccessFlags;Ljava/util/List;)Lkotlinx/validation/api/FieldBinarySignature;
-	public static synthetic fun copy$default (Lkotlinx/validation/api/FieldBinarySignature;Lkotlinx/metadata/jvm/JvmFieldSignature;ZLkotlinx/validation/api/AccessFlags;Ljava/util/List;ILjava/lang/Object;)Lkotlinx/validation/api/FieldBinarySignature;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun findMemberVisibility (Lkotlinx/validation/api/ClassVisibility;)Lkotlinx/validation/api/MemberVisibility;
-	public fun getAccess ()Lkotlinx/validation/api/AccessFlags;
-	public fun getAnnotations ()Ljava/util/List;
-	public fun getDesc ()Ljava/lang/String;
-	public fun getJvmMember ()Lkotlinx/metadata/jvm/JvmFieldSignature;
-	public synthetic fun getJvmMember ()Lkotlinx/metadata/jvm/JvmMemberSignature;
-	public fun getName ()Ljava/lang/String;
-	public fun getSignature ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun isEffectivelyPublic (Lkotlinx/validation/api/AccessFlags;Lkotlinx/validation/api/ClassVisibility;)Z
-	public fun isPublishedApi ()Z
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class kotlinx/validation/api/KotlinMetadataSignatureKt {
-	public static final fun getMEMBER_SORT_ORDER ()Ljava/util/Comparator;
-	public static final fun isCompanionField (Lkotlinx/validation/api/FieldBinarySignature;Lkotlinx/metadata/jvm/KotlinClassMetadata;)Z
-	public static final fun toFieldBinarySignature (Lorg/objectweb/asm/tree/FieldNode;Ljava/util/List;)Lkotlinx/validation/api/FieldBinarySignature;
-	public static final fun toMethodBinarySignature (Lorg/objectweb/asm/tree/MethodNode;Ljava/util/List;Lkotlinx/metadata/jvm/JvmMethodSignature;)Lkotlinx/validation/api/MethodBinarySignature;
-}
-
-public final class kotlinx/validation/api/KotlinMetadataVisibilitiesKt {
-	public static final fun findMember (Lkotlinx/validation/api/ClassVisibility;Lkotlinx/metadata/jvm/JvmMemberSignature;)Lkotlinx/validation/api/MemberVisibility;
-	public static final fun getKotlinMetadata (Lorg/objectweb/asm/tree/ClassNode;)Lkotlinx/metadata/jvm/KotlinClassMetadata;
-	public static final fun isFileOrMultipartFacade (Lkotlinx/metadata/jvm/KotlinClassMetadata;)Z
-	public static final fun isInternal (Lkotlinx/validation/api/MemberVisibility;)Z
-	public static final fun isPublic (Lkotlinx/validation/api/ClassVisibility;Z)Z
-	public static final fun isPublic (Lkotlinx/validation/api/MemberVisibility;Z)Z
-	public static final fun isSyntheticClass (Lkotlinx/metadata/jvm/KotlinClassMetadata;)Z
-	public static final fun readKotlinVisibilities (Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Ljava/util/Map;
-	public static synthetic fun readKotlinVisibilities$default (Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/util/Map;
-	public static final fun toClassVisibility (Lkotlinx/metadata/jvm/KotlinClassMetadata;Lorg/objectweb/asm/tree/ClassNode;)Lkotlinx/validation/api/ClassVisibility;
-	public static final fun toClassVisibility (Lorg/objectweb/asm/tree/ClassNode;)Lkotlinx/validation/api/ClassVisibility;
 }
 
 public final class kotlinx/validation/api/KotlinSignaturesLoadingKt {
@@ -216,71 +74,5 @@ public final class kotlinx/validation/api/KotlinSignaturesLoadingKt {
 	public static synthetic fun loadApiFromJvmClasses$default (Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun retainExplicitlyIncludedIfDeclared (Ljava/util/List;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;)Ljava/util/List;
 	public static synthetic fun retainExplicitlyIncludedIfDeclared$default (Ljava/util/List;Ljava/util/Collection;Ljava/util/Collection;Ljava/util/Collection;ILjava/lang/Object;)Ljava/util/List;
-}
-
-public abstract interface class kotlinx/validation/api/MemberBinarySignature {
-	public abstract fun findMemberVisibility (Lkotlinx/validation/api/ClassVisibility;)Lkotlinx/validation/api/MemberVisibility;
-	public abstract fun getAccess ()Lkotlinx/validation/api/AccessFlags;
-	public abstract fun getAnnotations ()Ljava/util/List;
-	public abstract fun getDesc ()Ljava/lang/String;
-	public abstract fun getJvmMember ()Lkotlinx/metadata/jvm/JvmMemberSignature;
-	public abstract fun getName ()Ljava/lang/String;
-	public abstract fun getSignature ()Ljava/lang/String;
-	public abstract fun isEffectivelyPublic (Lkotlinx/validation/api/AccessFlags;Lkotlinx/validation/api/ClassVisibility;)Z
-	public abstract fun isPublishedApi ()Z
-}
-
-public final class kotlinx/validation/api/MemberBinarySignature$DefaultImpls {
-	public static fun findMemberVisibility (Lkotlinx/validation/api/MemberBinarySignature;Lkotlinx/validation/api/ClassVisibility;)Lkotlinx/validation/api/MemberVisibility;
-	public static fun getDesc (Lkotlinx/validation/api/MemberBinarySignature;)Ljava/lang/String;
-	public static fun getName (Lkotlinx/validation/api/MemberBinarySignature;)Ljava/lang/String;
-	public static fun isEffectivelyPublic (Lkotlinx/validation/api/MemberBinarySignature;Lkotlinx/validation/api/AccessFlags;Lkotlinx/validation/api/ClassVisibility;)Z
-}
-
-public final class kotlinx/validation/api/MemberVisibility {
-	public fun <init> (Lkotlinx/metadata/jvm/JvmMemberSignature;Ljava/lang/Integer;ZLkotlinx/validation/api/PropertyAnnotationHolders;)V
-	public synthetic fun <init> (Lkotlinx/metadata/jvm/JvmMemberSignature;Ljava/lang/Integer;ZLkotlinx/validation/api/PropertyAnnotationHolders;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lkotlinx/metadata/jvm/JvmMemberSignature;
-	public final fun component2 ()Ljava/lang/Integer;
-	public final fun component3 ()Z
-	public final fun component4 ()Lkotlinx/validation/api/PropertyAnnotationHolders;
-	public final fun copy (Lkotlinx/metadata/jvm/JvmMemberSignature;Ljava/lang/Integer;ZLkotlinx/validation/api/PropertyAnnotationHolders;)Lkotlinx/validation/api/MemberVisibility;
-	public static synthetic fun copy$default (Lkotlinx/validation/api/MemberVisibility;Lkotlinx/metadata/jvm/JvmMemberSignature;Ljava/lang/Integer;ZLkotlinx/validation/api/PropertyAnnotationHolders;ILjava/lang/Object;)Lkotlinx/validation/api/MemberVisibility;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getMember ()Lkotlinx/metadata/jvm/JvmMemberSignature;
-	public final fun getPropertyAnnotation ()Lkotlinx/validation/api/PropertyAnnotationHolders;
-	public final fun getVisibility ()Ljava/lang/Integer;
-	public fun hashCode ()I
-	public final fun isReified ()Z
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class kotlinx/validation/api/MethodBinarySignature : kotlinx/validation/api/MemberBinarySignature {
-	public fun <init> (Lkotlinx/metadata/jvm/JvmMethodSignature;ZLkotlinx/validation/api/AccessFlags;Ljava/util/List;Lkotlinx/metadata/jvm/JvmMethodSignature;)V
-	public final fun component1 ()Lkotlinx/metadata/jvm/JvmMethodSignature;
-	public final fun component2 ()Z
-	public final fun component3 ()Lkotlinx/validation/api/AccessFlags;
-	public final fun component4 ()Ljava/util/List;
-	public final fun copy (Lkotlinx/metadata/jvm/JvmMethodSignature;ZLkotlinx/validation/api/AccessFlags;Ljava/util/List;Lkotlinx/metadata/jvm/JvmMethodSignature;)Lkotlinx/validation/api/MethodBinarySignature;
-	public static synthetic fun copy$default (Lkotlinx/validation/api/MethodBinarySignature;Lkotlinx/metadata/jvm/JvmMethodSignature;ZLkotlinx/validation/api/AccessFlags;Ljava/util/List;Lkotlinx/metadata/jvm/JvmMethodSignature;ILjava/lang/Object;)Lkotlinx/validation/api/MethodBinarySignature;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun findMemberVisibility (Lkotlinx/validation/api/ClassVisibility;)Lkotlinx/validation/api/MemberVisibility;
-	public fun getAccess ()Lkotlinx/validation/api/AccessFlags;
-	public fun getAnnotations ()Ljava/util/List;
-	public fun getDesc ()Ljava/lang/String;
-	public synthetic fun getJvmMember ()Lkotlinx/metadata/jvm/JvmMemberSignature;
-	public fun getJvmMember ()Lkotlinx/metadata/jvm/JvmMethodSignature;
-	public fun getName ()Ljava/lang/String;
-	public fun getSignature ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun isEffectivelyPublic (Lkotlinx/validation/api/AccessFlags;Lkotlinx/validation/api/ClassVisibility;)Z
-	public fun isPublishedApi ()Z
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class kotlinx/validation/api/PropertyAnnotationHolders {
-	public fun <init> (Lkotlinx/metadata/jvm/JvmFieldSignature;Lkotlinx/metadata/jvm/JvmMethodSignature;)V
-	public final fun getField ()Lkotlinx/metadata/jvm/JvmFieldSignature;
-	public final fun getMethod ()Lkotlinx/metadata/jvm/JvmMethodSignature;
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
 
 tasks.compileKotlin {
     compilerOptions {
+        freeCompilerArgs.add("-Xexplicit-api=strict")
         allWarningsAsErrors.set(true)
         @Suppress("DEPRECATION") // Compatibility with Gradle 7 requires Kotlin 1.4
         languageVersion.set(KotlinVersion.KOTLIN_1_4)

--- a/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/BaseKotlinGradleTest.kt
@@ -5,7 +5,6 @@
 
 package kotlinx.validation.api
 
-import kotlinx.validation.API_DIR
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import java.io.File

--- a/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
@@ -6,9 +6,10 @@
 package kotlinx.validation.api
 
 import java.io.*
-import kotlinx.validation.API_DIR
 import org.gradle.testkit.runner.GradleRunner
 import org.intellij.lang.annotations.Language
+
+public const val API_DIR: String = "api"
 
 internal fun BaseKotlinGradleTest.test(fn: BaseKotlinScope.() -> Unit): GradleRunner {
     val baseKotlinScope = BaseKotlinScope()

--- a/src/functionalTest/kotlin/kotlinx/validation/test/DefaultConfigTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/DefaultConfigTests.kt
@@ -5,7 +5,6 @@
 
 package kotlinx.validation.test
 
-import kotlinx.validation.API_DIR
 import kotlinx.validation.api.*
 import org.assertj.core.api.*
 import org.junit.Test

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultiPlatformSingleJvmTargetTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultiPlatformSingleJvmTargetTest.kt
@@ -5,7 +5,6 @@
 
 package kotlinx.validation.test
 
-import kotlinx.validation.API_DIR
 import kotlinx.validation.api.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test

--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
@@ -5,7 +5,6 @@
 
 package kotlinx.validation.test
 
-import kotlinx.validation.API_DIR
 import kotlinx.validation.api.*
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner

--- a/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnRootTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnRootTests.kt
@@ -5,7 +5,6 @@
 
 package kotlinx.validation.test
 
-import kotlinx.validation.API_DIR
 import kotlinx.validation.api.*
 import kotlinx.validation.api.BaseKotlinGradleTest
 import kotlinx.validation.api.assertTaskSuccess

--- a/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnSubTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/SubprojectsWithPluginOnSubTests.kt
@@ -5,7 +5,6 @@
 
 package kotlinx.validation.test
 
-import kotlinx.validation.API_DIR
 import kotlinx.validation.api.*
 import kotlinx.validation.api.BaseKotlinGradleTest
 import kotlinx.validation.api.assertTaskSuccess

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -5,12 +5,12 @@
 
 package kotlinx.validation
 
-open class ApiValidationExtension {
+public open class ApiValidationExtension {
 
     /**
      * Disables API validation checks completely.
      */
-    public var validationDisabled = false
+    public var validationDisabled: Boolean = false
 
     /**
      * Fully qualified package names that are not consider public API.

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o.
+ * Copyright 2016-2023 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
@@ -13,9 +13,9 @@ import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.plugin.*
 import java.io.*
 
-const val API_DIR = "api"
+private const val API_DIR = "api" // Mirrored in functional tests
 
-class BinaryCompatibilityValidatorPlugin : Plugin<Project> {
+public class BinaryCompatibilityValidatorPlugin : Plugin<Project> {
 
     override fun apply(target: Project): Unit = with(target) {
         val extension = extensions.create("apiValidation", ApiValidationExtension::class.java)
@@ -216,7 +216,7 @@ internal val Project.apiValidationExtensionOrNull: ApiValidationExtension?
             .map { it.extensions.findByType(ApiValidationExtension::class.java) }
             .firstOrNull { it != null }
 
-fun apiCheckEnabled(projectName: String, extension: ApiValidationExtension): Boolean =
+private fun apiCheckEnabled(projectName: String, extension: ApiValidationExtension): Boolean =
     projectName !in extension.ignoredProjects && !extension.validationDisabled
 
 private fun Project.configureApiTasks(
@@ -283,7 +283,7 @@ private fun Project.configureCheckTasks(
     }
 }
 
-inline fun <reified T : Task> Project.task(
+private inline fun <reified T : Task> Project.task(
     name: String,
     noinline configuration: T.() -> Unit,
 ): TaskProvider<T> = tasks.register(name, T::class.java, Action(configuration))

--- a/src/main/kotlin/ExternalApi.kt
+++ b/src/main/kotlin/ExternalApi.kt
@@ -9,4 +9,4 @@ package kotlinx.validation
  * API that is used externally and programmatically by binary-compatibility-validator tool in Kotlin standard library
  */
 @Retention(AnnotationRetention.SOURCE)
-annotation class ExternalApi
+public annotation class ExternalApi

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -13,7 +13,7 @@ import java.io.*
 import java.util.jar.JarFile
 import javax.inject.Inject
 
-open class KotlinApiBuildTask @Inject constructor(
+public open class KotlinApiBuildTask @Inject constructor(
 ) : DefaultTask() {
 
     private val extension = project.apiValidationExtensionOrNull
@@ -21,53 +21,53 @@ open class KotlinApiBuildTask @Inject constructor(
     @InputFiles
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
-    var inputClassesDirs: FileCollection? = null
+    public var inputClassesDirs: FileCollection? = null
 
     @InputFile
     @Optional
     @PathSensitive(PathSensitivity.RELATIVE)
-    val inputJar: RegularFileProperty = this.project.objects.fileProperty()
+    public val inputJar: RegularFileProperty = this.project.objects.fileProperty()
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    lateinit var inputDependencies: FileCollection
+    public lateinit var inputDependencies: FileCollection
 
     @OutputDirectory
-    lateinit var outputApiDir: File
+    public lateinit var outputApiDir: File
 
     private var _ignoredPackages: Set<String>? = null
     @get:Input
-    var ignoredPackages : Set<String>
+    internal var ignoredPackages : Set<String>
         get() = _ignoredPackages ?: extension?.ignoredPackages ?: emptySet()
         set(value) { _ignoredPackages = value }
 
     private var _nonPublicMarkes: Set<String>? = null
     @get:Input
-    var nonPublicMarkers : Set<String>
+    internal var nonPublicMarkers : Set<String>
         get() = _nonPublicMarkes ?: extension?.nonPublicMarkers ?: emptySet()
         set(value) { _nonPublicMarkes = value }
 
     private var _ignoredClasses: Set<String>? = null
     @get:Input
-    var ignoredClasses : Set<String>
+    internal var ignoredClasses : Set<String>
         get() = _ignoredClasses ?: extension?.ignoredClasses ?: emptySet()
         set(value) { _ignoredClasses = value }
 
     private var _publicPackages: Set<String>? = null
     @get:Input
-    var publicPackages: Set<String>
+    internal var publicPackages: Set<String>
         get() = _publicPackages ?: extension?.publicPackages ?: emptySet()
         set(value) { _publicPackages = value }
 
     private var _publicMarkers: Set<String>? = null
     @get:Input
-    var publicMarkers: Set<String>
+    internal var publicMarkers: Set<String>
         get() = _publicMarkers ?: extension?.publicMarkers ?: emptySet()
         set(value) { _publicMarkers = value}
 
     private var _publicClasses: Set<String>? = null
     @get:Input
-    var publicClasses: Set<String>
+    internal var publicClasses: Set<String>
         get() = _publicClasses ?: extension?.publicClasses ?: emptySet()
         set(value) { _publicClasses = value }
 
@@ -75,7 +75,7 @@ open class KotlinApiBuildTask @Inject constructor(
     internal val projectName = project.name
 
     @TaskAction
-    fun generate() {
+    internal fun generate() {
         cleanup(outputApiDir)
         outputApiDir.mkdirs()
 

--- a/src/main/kotlin/KotlinApiCompareTask.kt
+++ b/src/main/kotlin/KotlinApiCompareTask.kt
@@ -15,7 +15,7 @@ import org.gradle.api.file.*
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.*
 
-open class KotlinApiCompareTask @Inject constructor(private val objects: ObjectFactory): DefaultTask() {
+public open class KotlinApiCompareTask @Inject constructor(private val objects: ObjectFactory): DefaultTask() {
 
     /*
      * Nullability and optionality is a workaround for
@@ -26,14 +26,14 @@ open class KotlinApiCompareTask @Inject constructor(private val objects: ObjectF
     @Optional
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    var projectApiDir: File? = null
+    public var projectApiDir: File? = null
 
     // Used for diagnostic error message when projectApiDir doesn't exist
     @Input
     @Optional
-    var nonExistingProjectApiDir: String? = null
+    public var nonExistingProjectApiDir: String? = null
 
-    fun compareApiDumps(apiReferenceDir: File, apiBuildDir: File) {
+    internal fun compareApiDumps(apiReferenceDir: File, apiBuildDir: File) {
         if (apiReferenceDir.exists()) {
             projectApiDir = apiReferenceDir
         } else {
@@ -45,19 +45,19 @@ open class KotlinApiCompareTask @Inject constructor(private val objects: ObjectF
 
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    lateinit var apiBuildDir: File
+    public lateinit var apiBuildDir: File
 
     @OutputFile
     @Optional
     @Suppress("unused")
-    val dummyOutputFile: File? = null
+    public val dummyOutputFile: File? = null
 
     private val projectName = project.name
 
     private val rootDir = project.rootProject.rootDir
 
     @TaskAction
-    fun verify() {
+    internal fun verify() {
         val projectApiDir = projectApiDir
             ?: error("Expected folder with API declarations '$nonExistingProjectApiDir' does not exist.\n" +
                     "Please ensure that ':apiDump' was executed in order to get API dump to compare the build against")

--- a/src/main/kotlin/api/AsmMetadataLoading.kt
+++ b/src/main/kotlin/api/AsmMetadataLoading.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o.
+ * Copyright 2016-2023 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
@@ -9,7 +9,7 @@ import kotlinx.metadata.jvm.*
 import org.objectweb.asm.*
 import org.objectweb.asm.tree.*
 
-val ACCESS_NAMES = mapOf(
+internal val ACCESS_NAMES = mapOf(
     Opcodes.ACC_PUBLIC to "public",
     Opcodes.ACC_PROTECTED to "protected",
     Opcodes.ACC_PRIVATE to "private",
@@ -21,13 +21,13 @@ val ACCESS_NAMES = mapOf(
     Opcodes.ACC_ANNOTATION to "annotation"
 )
 
-fun isPublic(access: Int) = access and Opcodes.ACC_PUBLIC != 0 || access and Opcodes.ACC_PROTECTED != 0
-fun isProtected(access: Int) = access and Opcodes.ACC_PROTECTED != 0
-fun isStatic(access: Int) = access and Opcodes.ACC_STATIC != 0
-fun isFinal(access: Int) = access and Opcodes.ACC_FINAL != 0
-fun isSynthetic(access: Int) = access and Opcodes.ACC_SYNTHETIC != 0
+internal fun isPublic(access: Int) = access and Opcodes.ACC_PUBLIC != 0 || access and Opcodes.ACC_PROTECTED != 0
+internal fun isProtected(access: Int) = access and Opcodes.ACC_PROTECTED != 0
+internal fun isStatic(access: Int) = access and Opcodes.ACC_STATIC != 0
+internal fun isFinal(access: Int) = access and Opcodes.ACC_FINAL != 0
+internal fun isSynthetic(access: Int) = access and Opcodes.ACC_SYNTHETIC != 0
 
-fun ClassNode.isEffectivelyPublic(classVisibility: ClassVisibility?) =
+internal fun ClassNode.isEffectivelyPublic(classVisibility: ClassVisibility?) =
     isPublic(access)
             && !isLocal()
             && !isWhenMappings()
@@ -36,27 +36,26 @@ fun ClassNode.isEffectivelyPublic(classVisibility: ClassVisibility?) =
             && (classVisibility?.isPublic(isPublishedApi()) ?: true)
 
 
-val ClassNode.innerClassNode: InnerClassNode? get() = innerClasses.singleOrNull { it.name == name }
-fun ClassNode.isLocal() = outerMethod != null
-fun ClassNode.isInner() = innerClassNode != null
-fun ClassNode.isWhenMappings() = isSynthetic(access) && name.endsWith("\$WhenMappings")
-fun ClassNode.isSyntheticAnnotationClass() = isSynthetic(access) && name.contains("\$annotationImpl\$")
-fun ClassNode.isEnumEntriesMappings() = isSynthetic(access) && name.endsWith("\$EntriesMappings")
+private val ClassNode.innerClassNode: InnerClassNode? get() = innerClasses.singleOrNull { it.name == name }
+private fun ClassNode.isLocal() = outerMethod != null
+private fun ClassNode.isInner() = innerClassNode != null
+private fun ClassNode.isWhenMappings() = isSynthetic(access) && name.endsWith("\$WhenMappings")
+private fun ClassNode.isSyntheticAnnotationClass() = isSynthetic(access) && name.contains("\$annotationImpl\$")
+private fun ClassNode.isEnumEntriesMappings() = isSynthetic(access) && name.endsWith("\$EntriesMappings")
 
-val ClassNode.effectiveAccess: Int get() = innerClassNode?.access ?: access
-val ClassNode.outerClassName: String? get() = innerClassNode?.outerName
-
-
-const val publishedApiAnnotationName = "kotlin/PublishedApi"
-fun ClassNode.isPublishedApi() = findAnnotation(publishedApiAnnotationName, includeInvisible = true) != null
-fun List<AnnotationNode>.isPublishedApi() = firstOrNull { it.refersToName(publishedApiAnnotationName) } != null
-
-fun ClassNode.isDefaultImpls(metadata: KotlinClassMetadata?) = isInner() && name.endsWith("\$DefaultImpls") && metadata.isSyntheticClass()
+internal val ClassNode.effectiveAccess: Int get() = innerClassNode?.access ?: access
+internal val ClassNode.outerClassName: String? get() = innerClassNode?.outerName
 
 
-fun ClassNode.findAnnotation(annotationName: String, includeInvisible: Boolean = false) =
+private const val publishedApiAnnotationName = "kotlin/PublishedApi"
+private fun ClassNode.isPublishedApi() = findAnnotation(publishedApiAnnotationName, includeInvisible = true) != null
+internal fun List<AnnotationNode>.isPublishedApi() = firstOrNull { it.refersToName(publishedApiAnnotationName) } != null
+
+internal fun ClassNode.isDefaultImpls(metadata: KotlinClassMetadata?) = isInner() && name.endsWith("\$DefaultImpls") && metadata.isSyntheticClass()
+
+internal fun ClassNode.findAnnotation(annotationName: String, includeInvisible: Boolean = false) =
     findAnnotation(annotationName, visibleAnnotations, invisibleAnnotations, includeInvisible)
-operator fun AnnotationNode.get(key: String): Any? = values.annotationValue(key)
+internal operator fun AnnotationNode.get(key: String): Any? = values.annotationValue(key)
 
 private fun List<Any>.annotationValue(key: String): Any? {
     for (index in (0 until size / 2)) {
@@ -75,5 +74,5 @@ private fun findAnnotation(
     visibleAnnotations?.firstOrNull { it.refersToName(annotationName) }
         ?: if (includeInvisible) invisibleAnnotations?.firstOrNull { it.refersToName(annotationName) } else null
 
-fun AnnotationNode.refersToName(name: String) =
+internal fun AnnotationNode.refersToName(name: String) =
     desc.startsWith('L') && desc.endsWith(';') && desc.regionMatches(1, name, 0, name.length)

--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -224,7 +224,7 @@ public fun List<ClassBinarySignature>.retainExplicitlyIncludedIfDeclared(
 }
 
 @ExternalApi
-public fun List<ClassBinarySignature>.dump() = dump(to = System.out)
+public fun List<ClassBinarySignature>.dump(): PrintStream = dump(to = System.out)
 
 @ExternalApi
 public fun <T : Appendable> List<ClassBinarySignature>.dump(to: T): T {


### PR DESCRIPTION
Rationale:

We know have quite a lot of accidentally public entities while both promoting and using BCV as a standalone JAR dependency. Apart from that, we have quite an unfortunate package name 'api' that might imply all these methods are part of public API (when, in fact, it's all related to API validation).

It would be nice to explicitly confine our visibilities and be more deliberate about that