### PR TITLE
Configure output directory for dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ apiValidation {
      * Flag to programmatically disable compatibility validator
      */
     validationDisabled = true
+
+    /**
+     * A path to a subdirectory inside the project root directory, where dumps should be stored.
+     */
+    apiDumpDirectory = "api"
 }
 ```
 
@@ -123,6 +128,11 @@ apiValidation {
      * Flag to programmatically disable compatibility validator
      */
     validationDisabled = false
+
+    /**
+     * A path to a subdirectory inside the project root directory, where dumps should be stored.
+     */
+    apiDumpDirectory = "aux/validation"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ apiValidation {
     validationDisabled = true
 
     /**
-     * A path to a subdirectory inside the project root directory, where dumps should be stored.
+     * A path to a subdirectory inside the project root directory where dumps should be stored.
      */
     apiDumpDirectory = "api"
 }
@@ -130,7 +130,7 @@ apiValidation {
     validationDisabled = false
 
     /**
-     * A path to a subdirectory inside the project root directory, where dumps should be stored.
+     * A path to a subdirectory inside the project root directory where dumps should be stored.
      */
     apiDumpDirectory = "aux/validation"
 }

--- a/api/binary-compatibility-validator.api
+++ b/api/binary-compatibility-validator.api
@@ -1,6 +1,7 @@
 public class kotlinx/validation/ApiValidationExtension {
 	public fun <init> ()V
 	public final fun getAdditionalSourceSets ()Ljava/util/Set;
+	public final fun getApiDumpDirectory ()Ljava/lang/String;
 	public final fun getIgnoredClasses ()Ljava/util/Set;
 	public final fun getIgnoredPackages ()Ljava/util/Set;
 	public final fun getIgnoredProjects ()Ljava/util/Set;
@@ -10,6 +11,7 @@ public class kotlinx/validation/ApiValidationExtension {
 	public final fun getPublicPackages ()Ljava/util/Set;
 	public final fun getValidationDisabled ()Z
 	public final fun setAdditionalSourceSets (Ljava/util/Set;)V
+	public final fun setApiDumpDirectory (Ljava/lang/String;)V
 	public final fun setIgnoredClasses (Ljava/util/Set;)V
 	public final fun setIgnoredPackages (Ljava/util/Set;)V
 	public final fun setIgnoredProjects (Ljava/util/Set;)V

--- a/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
@@ -5,11 +5,12 @@
 
 package kotlinx.validation.api
 
+import kotlinx.validation.ApiValidationExtension
 import java.io.*
 import org.gradle.testkit.runner.GradleRunner
 import org.intellij.lang.annotations.Language
 
-public const val API_DIR: String = "api"
+public val API_DIR: String = ApiValidationExtension().apiDumpDirectory
 
 internal fun BaseKotlinGradleTest.test(fn: BaseKotlinScope.() -> Unit): GradleRunner {
     val baseKotlinScope = BaseKotlinScope()

--- a/src/functionalTest/kotlin/kotlinx/validation/test/OutputDirectoryTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/OutputDirectoryTests.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.validation.test
+
+import kotlinx.validation.api.*
+import kotlinx.validation.api.buildGradleKts
+import kotlinx.validation.api.resolve
+import kotlinx.validation.api.test
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class OutputDirectoryTests : BaseKotlinGradleTest() {
+    @Test
+    fun dumpIntoCustomDirectory() {
+        val runner = test {
+            buildGradleKts {
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/outputDirectory/different.gradle.kts")
+            }
+
+            kotlin("AnotherBuildConfig.kt") {
+                resolve("/examples/classes/AnotherBuildConfig.kt")
+            }
+            dir("api") {
+                file("letMeBe.txt") {
+                }
+            }
+
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            val dumpFile = rootProjectDir.resolve("custom").resolve("${rootProjectDir.name}.api")
+            assertTrue(dumpFile.exists(), "api dump file ${dumpFile.path} should exist")
+
+            val expected = readFileList("/examples/classes/AnotherBuildConfig.dump")
+            Assertions.assertThat(dumpFile.readText()).isEqualToIgnoringNewLines(expected)
+
+            val fileInsideDir = rootProjectDir.resolve("api").resolve("letMeBe.txt")
+            assertTrue(fileInsideDir.exists(), "existing api directory should not be overridden")
+        }
+    }
+
+    @Test
+    fun validateDumpFromACustomDirectory() {
+        val runner = test {
+            buildGradleKts {
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/outputDirectory/different.gradle.kts")
+            }
+
+            kotlin("AnotherBuildConfig.kt") {
+                resolve("/examples/classes/AnotherBuildConfig.kt")
+            }
+            dir("custom") {
+                file("${rootProjectDir.name}.api") {
+                    resolve("/examples/classes/AnotherBuildConfig.dump")
+                }
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+
+    @Test
+    fun dumpIntoSubdirectory() {
+        val runner = test {
+            buildGradleKts {
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/outputDirectory/subdirectory.gradle.kts")
+            }
+
+            kotlin("AnotherBuildConfig.kt") {
+                resolve("/examples/classes/AnotherBuildConfig.kt")
+            }
+
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            val dumpFile = rootProjectDir.resolve("validation")
+                .resolve("api")
+                .resolve("${rootProjectDir.name}.api")
+
+            assertTrue(dumpFile.exists(), "api dump file ${dumpFile.path} should exist")
+
+            val expected = readFileList("/examples/classes/AnotherBuildConfig.dump")
+            Assertions.assertThat(dumpFile.readText()).isEqualToIgnoringNewLines(expected)
+        }
+    }
+
+    @Test
+    fun validateDumpFromASubdirectory() {
+        val runner = test {
+            buildGradleKts {
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/outputDirectory/subdirectory.gradle.kts")
+            }
+
+            kotlin("AnotherBuildConfig.kt") {
+                resolve("/examples/classes/AnotherBuildConfig.kt")
+            }
+            dir("validation") {
+                dir("api") {
+                    file("${rootProjectDir.name}.api") {
+                        resolve("/examples/classes/AnotherBuildConfig.dump")
+                    }
+                }
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiCheck")
+        }
+    }
+}

--- a/src/functionalTest/kotlin/kotlinx/validation/test/OutputDirectoryTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/OutputDirectoryTests.kt
@@ -154,7 +154,7 @@ class OutputDirectoryTests : BaseKotlinGradleTest() {
         }
 
         runner.buildAndFail().apply {
-            Assertions.assertThat(output).contains("apiDumpDirectory should be inside the project directory")
+            Assertions.assertThat(output).contains("apiDumpDirectory (\"../api\") should be inside the project directory")
         }
     }
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/OutputDirectoryTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/OutputDirectoryTests.kt
@@ -135,4 +135,26 @@ class OutputDirectoryTests : BaseKotlinGradleTest() {
             assertTaskSuccess(":apiCheck")
         }
     }
+
+    @Test
+    fun dumpIntoParentDirectory() {
+        val runner = test {
+            buildGradleKts {
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/outputDirectory/outer.gradle.kts")
+            }
+
+            kotlin("AnotherBuildConfig.kt") {
+                resolve("/examples/classes/AnotherBuildConfig.kt")
+            }
+
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.buildAndFail().apply {
+            Assertions.assertThat(output).contains("apiDumpDirectory should be inside the project directory")
+        }
+    }
 }

--- a/src/functionalTest/resources/examples/gradle/configuration/outputDirectory/different.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/outputDirectory/different.gradle.kts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    apiDumpDirectory = "custom"
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/outputDirectory/outer.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/outputDirectory/outer.gradle.kts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    apiDumpDirectory = "../api"
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/outputDirectory/subdirectory.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/outputDirectory/subdirectory.gradle.kts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    apiDumpDirectory = "validation/api"
+}

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -67,7 +67,8 @@ public open class ApiValidationExtension {
 
     /**
      * A path to a directory containing an API dump.
-     * The path should be relative to the project's root directory and by default it's `api`.
+     * The path should be relative to the project's root directory and should resolve to its subdirectory.
+     * By default, it's `api`.
      */
     public var apiDumpDirectory: String = "api"
 }

--- a/src/main/kotlin/ApiValidationExtension.kt
+++ b/src/main/kotlin/ApiValidationExtension.kt
@@ -64,4 +64,10 @@ public open class ApiValidationExtension {
      * By default, only the `main` source set is checked.
      */
     public var additionalSourceSets: MutableSet<String> = HashSet()
+
+    /**
+     * A path to a directory containing an API dump.
+     * The path should be relative to the project's root directory and by default it's `api`.
+     */
+    public var apiDumpDirectory: String = "api"
 }

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -141,8 +141,8 @@ private class TargetConfig constructor(
     private val apiDirProvider = project.provider {
         val dir = extension.apiDumpDirectory
 
-        val root = project.layout.projectDirectory.asFile.toPath().toAbsolutePath()
-        val resolvedDir = root.resolve(dir).toAbsolutePath()
+        val root = project.layout.projectDirectory.asFile.toPath().toAbsolutePath().normalize()
+        val resolvedDir = root.resolve(dir).normalize()
         if (!resolvedDir.startsWith(root)) {
             throw IllegalArgumentException("apiDumpDirectory should be inside the project directory")
         }

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -145,7 +145,8 @@ private class TargetConfig constructor(
         val resolvedDir = root.resolve(dir).normalize()
         if (!resolvedDir.startsWith(root)) {
             throw IllegalArgumentException("apiDumpDirectory (\"$dir\") should be inside the project directory, " +
-                    "but it resolves to a path outside the project root.")
+                    "but it resolves to a path outside the project root.\n" +
+                    "Project's root path: $root\nResolved apiDumpDirectory: $resolvedDir")
         }
 
         dir

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -144,7 +144,8 @@ private class TargetConfig constructor(
         val root = project.layout.projectDirectory.asFile.toPath().toAbsolutePath().normalize()
         val resolvedDir = root.resolve(dir).normalize()
         if (!resolvedDir.startsWith(root)) {
-            throw IllegalArgumentException("apiDumpDirectory should be inside the project directory")
+            throw IllegalArgumentException("apiDumpDirectory (\"$dir\") should be inside the project directory, " +
+                    "but it resolves to a path outside the project root.")
         }
 
         dir


### PR DESCRIPTION
Added an option to configure a path to a directory where dumps are stored:

``` 
apiValidation {
   apiDumpDirectory = "a/b/c/d/e"
}
```

By default, that path remains `api`.

It's an error to specify a path that leads outside the project directory.

Fixes #127 