### PR TITLE
Support Java package-level annotations

### DIFF
--- a/api/binary-compatibility-validator.api
+++ b/api/binary-compatibility-validator.api
@@ -67,6 +67,7 @@ public final class kotlinx/validation/api/ClassBinarySignature {
 public final class kotlinx/validation/api/KotlinSignaturesLoadingKt {
 	public static final fun dump (Ljava/util/List;)Ljava/io/PrintStream;
 	public static final fun dump (Ljava/util/List;Ljava/lang/Appendable;)Ljava/lang/Appendable;
+	public static final fun extractAnnotatedPackages (Ljava/util/List;Ljava/util/Set;)Ljava/util/List;
 	public static final fun filterOutAnnotated (Ljava/util/List;Ljava/util/Set;)Ljava/util/List;
 	public static final fun filterOutNonPublic (Ljava/util/List;Ljava/util/Collection;Ljava/util/Collection;)Ljava/util/List;
 	public static synthetic fun filterOutNonPublic$default (Ljava/util/List;Ljava/util/Collection;Ljava/util/Collection;ILjava/lang/Object;)Ljava/util/List;

--- a/src/functionalTest/kotlin/kotlinx/validation/test/NonPublicMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/NonPublicMarkersTest.kt
@@ -42,20 +42,20 @@ class NonPublicMarkersTest : BaseKotlinGradleTest() {
     fun testFiltrationByPackageLevelAnnotations() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
-                resolve("examples/gradle/configuration/nonPublicMarkers/packages.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/nonPublicMarkers/packages.gradle.kts")
             }
             java("annotated/PackageAnnotation.java") {
-                resolve("examples/classes/PackageAnnotation.java")
+                resolve("/examples/classes/PackageAnnotation.java")
             }
             java("annotated/package-info.java") {
-                resolve("examples/classes/package-info.java")
+                resolve("/examples/classes/package-info.java")
             }
             kotlin("ClassFromAnnotatedPackage.kt") {
-                resolve("examples/classes/ClassFromAnnotatedPackage.kt")
+                resolve("/examples/classes/ClassFromAnnotatedPackage.kt")
             }
             kotlin("AnotherBuildConfig.kt") {
-                resolve("examples/classes/AnotherBuildConfig.kt")
+                resolve("/examples/classes/AnotherBuildConfig.kt")
             }
             runner {
                 arguments.add(":apiDump")
@@ -67,7 +67,7 @@ class NonPublicMarkersTest : BaseKotlinGradleTest() {
 
             assertTrue(rootProjectApiDump.exists(), "api dump file should exist")
 
-            val expected = readFileList("examples/classes/AnotherBuildConfig.dump")
+            val expected = readFileList("/examples/classes/AnotherBuildConfig.dump")
             Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
         }
     }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/NonPublicMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/NonPublicMarkersTest.kt
@@ -6,7 +6,9 @@
 package kotlinx.validation.test
 
 import kotlinx.validation.api.*
+import org.assertj.core.api.Assertions
 import org.junit.*
+import kotlin.test.assertTrue
 
 class NonPublicMarkersTest : BaseKotlinGradleTest() {
 
@@ -33,6 +35,40 @@ class NonPublicMarkersTest : BaseKotlinGradleTest() {
 
         runner.build().apply {
             assertTaskSuccess(":apiCheck")
+        }
+    }
+
+    @Test
+    fun testFiltrationByPackageLevelAnnotations() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/nonPublicMarkers/packages.gradle.kts")
+            }
+            java("annotated/PackageAnnotation.java") {
+                resolve("examples/classes/PackageAnnotation.java")
+            }
+            java("annotated/package-info.java") {
+                resolve("examples/classes/package-info.java")
+            }
+            kotlin("ClassFromAnnotatedPackage.kt") {
+                resolve("examples/classes/ClassFromAnnotatedPackage.kt")
+            }
+            kotlin("AnotherBuildConfig.kt") {
+                resolve("examples/classes/AnotherBuildConfig.kt")
+            }
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            assertTrue(rootProjectApiDump.exists(), "api dump file should exist")
+
+            val expected = readFileList("examples/classes/AnotherBuildConfig.dump")
+            Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
         }
     }
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/PublicMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/PublicMarkersTest.kt
@@ -50,20 +50,20 @@ class PublicMarkersTest : BaseKotlinGradleTest() {
     fun testFiltrationByPackageLevelAnnotations() {
         val runner = test {
             buildGradleKts {
-                resolve("examples/gradle/base/withPlugin.gradle.kts")
-                resolve("examples/gradle/configuration/publicMarkers/packages.gradle.kts")
+                resolve("/examples/gradle/base/withPlugin.gradle.kts")
+                resolve("/examples/gradle/configuration/publicMarkers/packages.gradle.kts")
             }
             java("annotated/PackageAnnotation.java") {
-                resolve("examples/classes/PackageAnnotation.java")
+                resolve("/examples/classes/PackageAnnotation.java")
             }
             java("annotated/package-info.java") {
-                resolve("examples/classes/package-info.java")
+                resolve("/examples/classes/package-info.java")
             }
             kotlin("ClassFromAnnotatedPackage.kt") {
-                resolve("examples/classes/ClassFromAnnotatedPackage.kt")
+                resolve("/examples/classes/ClassFromAnnotatedPackage.kt")
             }
             kotlin("AnotherBuildConfig.kt") {
-                resolve("examples/classes/AnotherBuildConfig.kt")
+                resolve("/examples/classes/AnotherBuildConfig.kt")
             }
             runner {
                 arguments.add(":apiDump")
@@ -75,7 +75,7 @@ class PublicMarkersTest : BaseKotlinGradleTest() {
 
             assertTrue(rootProjectApiDump.exists(), "api dump file should exist")
 
-            val expected = readFileList("examples/classes/AnnotatedPackage.dump")
+            val expected = readFileList("/examples/classes/AnnotatedPackage.dump")
             Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
         }
     }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/PublicMarkersTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/PublicMarkersTest.kt
@@ -10,7 +10,9 @@ import kotlinx.validation.api.buildGradleKts
 import kotlinx.validation.api.kotlin
 import kotlinx.validation.api.resolve
 import kotlinx.validation.api.test
+import org.assertj.core.api.Assertions
 import org.junit.Test
+import kotlin.test.assertTrue
 
 class PublicMarkersTest : BaseKotlinGradleTest() {
 
@@ -41,6 +43,40 @@ class PublicMarkersTest : BaseKotlinGradleTest() {
 
         runner.withDebug(true).build().apply {
             assertTaskSuccess(":apiCheck")
+        }
+    }
+
+    @Test
+    fun testFiltrationByPackageLevelAnnotations() {
+        val runner = test {
+            buildGradleKts {
+                resolve("examples/gradle/base/withPlugin.gradle.kts")
+                resolve("examples/gradle/configuration/publicMarkers/packages.gradle.kts")
+            }
+            java("annotated/PackageAnnotation.java") {
+                resolve("examples/classes/PackageAnnotation.java")
+            }
+            java("annotated/package-info.java") {
+                resolve("examples/classes/package-info.java")
+            }
+            kotlin("ClassFromAnnotatedPackage.kt") {
+                resolve("examples/classes/ClassFromAnnotatedPackage.kt")
+            }
+            kotlin("AnotherBuildConfig.kt") {
+                resolve("examples/classes/AnotherBuildConfig.kt")
+            }
+            runner {
+                arguments.add(":apiDump")
+            }
+        }
+
+        runner.build().apply {
+            assertTaskSuccess(":apiDump")
+
+            assertTrue(rootProjectApiDump.exists(), "api dump file should exist")
+
+            val expected = readFileList("examples/classes/AnnotatedPackage.dump")
+            Assertions.assertThat(rootProjectApiDump.readText()).isEqualToIgnoringNewLines(expected)
         }
     }
 }

--- a/src/functionalTest/resources/examples/classes/AnnotatedPackage.dump
+++ b/src/functionalTest/resources/examples/classes/AnnotatedPackage.dump
@@ -1,0 +1,6 @@
+public final class annotated/ClassFromAnnotatedPackage {
+	public fun <init> ()V
+}
+
+public abstract interface annotation class annotated/PackageAnnotation : java/lang/annotation/Annotation {
+}

--- a/src/functionalTest/resources/examples/classes/ClassFromAnnotatedPackage.kt
+++ b/src/functionalTest/resources/examples/classes/ClassFromAnnotatedPackage.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package annotated
+
+class ClassFromAnnotatedPackage {
+}

--- a/src/functionalTest/resources/examples/classes/PackageAnnotation.java
+++ b/src/functionalTest/resources/examples/classes/PackageAnnotation.java
@@ -1,0 +1,11 @@
+package annotated;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PACKAGE)
+public @interface PackageAnnotation {
+}

--- a/src/functionalTest/resources/examples/classes/package-info.java
+++ b/src/functionalTest/resources/examples/classes/package-info.java
@@ -1,0 +1,2 @@
+@PackageAnnotation
+package annotated;

--- a/src/functionalTest/resources/examples/gradle/configuration/nonPublicMarkers/packages.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/nonPublicMarkers/packages.gradle.kts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    nonPublicMarkers.add("annotated.PackageAnnotation")
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/publicMarkers/packages.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/publicMarkers/packages.gradle.kts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+configure<kotlinx.validation.ApiValidationExtension> {
+    publicMarkers.add("annotated.PackageAnnotation")
+}

--- a/src/main/kotlin/KotlinApiBuildTask.kt
+++ b/src/main/kotlin/KotlinApiBuildTask.kt
@@ -95,10 +95,13 @@ public open class KotlinApiBuildTask @Inject constructor(
                 throw GradleException("KotlinApiBuildTask should have either inputClassesDirs, or inputJar property set")
         }
 
+        val publicPackagesNames = signatures.extractAnnotatedPackages(publicMarkers.map(::replaceDots).toSet())
+        val ignoredPackagesNames = signatures.extractAnnotatedPackages(nonPublicMarkers.map(::replaceDots).toSet())
 
         val filteredSignatures = signatures
-            .retainExplicitlyIncludedIfDeclared(publicPackages, publicClasses, publicMarkers)
-            .filterOutNonPublic(ignoredPackages, ignoredClasses)
+            .retainExplicitlyIncludedIfDeclared(publicPackages + publicPackagesNames,
+                publicClasses, publicMarkers)
+            .filterOutNonPublic(ignoredPackages + ignoredPackagesNames, ignoredClasses)
             .filterOutAnnotated(nonPublicMarkers.map(::replaceDots).toSet())
 
         outputApiDir.resolve("$projectName.api").bufferedWriter().use { writer ->

--- a/src/main/kotlin/api/AsmMetadataLoading.kt
+++ b/src/main/kotlin/api/AsmMetadataLoading.kt
@@ -26,6 +26,8 @@ internal fun isProtected(access: Int) = access and Opcodes.ACC_PROTECTED != 0
 internal fun isStatic(access: Int) = access and Opcodes.ACC_STATIC != 0
 internal fun isFinal(access: Int) = access and Opcodes.ACC_FINAL != 0
 internal fun isSynthetic(access: Int) = access and Opcodes.ACC_SYNTHETIC != 0
+internal fun isAbstract(access: Int) = access and Opcodes.ACC_ABSTRACT != 0
+internal fun isInterface(access: Int) = access and Opcodes.ACC_INTERFACE != 0
 
 internal fun ClassNode.isEffectivelyPublic(classVisibility: ClassVisibility?) =
     isPublic(access)

--- a/src/main/kotlin/api/KotlinMetadataSignature.kt
+++ b/src/main/kotlin/api/KotlinMetadataSignature.kt
@@ -157,6 +157,8 @@ internal data class AccessFlags(val access: Int) {
     val isStatic: Boolean get() = isStatic(access)
     val isFinal: Boolean get() = isFinal(access)
     val isSynthetic: Boolean get() = isSynthetic(access)
+    val isAbstract: Boolean get() = isAbstract(access)
+    val isInterface: Boolean get() = isInterface(access)
 
     private fun getModifiers(): List<String> =
         ACCESS_NAMES.entries.mapNotNull { if (access and it.key != 0) it.value else null }

--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -218,12 +218,23 @@ private fun List<ClassBinarySignature>.filterOutNotAnnotated(
     }
 }
 
+/**
+ * Extracts name of packages annotated by one of the [targetAnnotations].
+ * If there are no such packages, returns an empty list.
+ *
+ * Package is checked for being annotated by looking at classes with `package-info` name
+ * ([see JSL 7.4.1](https://docs.oracle.com/javase/specs/jls/se21/html/jls-7.html#jls-7.4)
+ * for details about `package-info`).
+ */
 @ExternalApi
 public fun List<ClassBinarySignature>.extractAnnotatedPackages(targetAnnotations: Set<String>): List<String> {
     if (targetAnnotations.isEmpty()) return emptyList()
 
     return filter {
         it.name.endsWith("/package-info")
+    }.filter {
+        // package-info classes are private synthetic abstract interfaces since 2005 (JDK-6232928).
+        it.access.isInterface && it.access.isSynthetic && it.access.isAbstract
     }.filter {
         it.annotations.any {
             ann -> targetAnnotations.any { ann.refersToName(it) }

--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -225,9 +225,12 @@ public fun List<ClassBinarySignature>.extractAnnotatedPackages(targetAnnotations
     return filter {
         it.name.endsWith("/package-info")
     }.filter {
-        it.annotations.all { ann -> targetAnnotations.any { ann.refersToName(it) } }
+        it.annotations.any {
+            ann -> targetAnnotations.any { ann.refersToName(it) }
+        }
     }.map {
-        it.name.substring(0, it.name.length - "/package-info".length)
+        val res = it.name.substring(0, it.name.length - "/package-info".length)
+        res
     }
 }
 

--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -219,6 +219,19 @@ private fun List<ClassBinarySignature>.filterOutNotAnnotated(
 }
 
 @ExternalApi
+public fun List<ClassBinarySignature>.extractAnnotatedPackages(targetAnnotations: Set<String>): List<String> {
+    if (targetAnnotations.isEmpty()) return emptyList()
+
+    return filter {
+        it.name.endsWith("/package-info")
+    }.filter {
+        it.annotations.all { ann -> targetAnnotations.any { ann.refersToName(it) } }
+    }.map {
+        it.name.substring(0, it.name.length - "/package-info".length)
+    }
+}
+
+@ExternalApi
 public fun List<ClassBinarySignature>.filterOutNonPublic(
     nonPublicPackages: Collection<String> = emptyList(),
     nonPublicClasses: Collection<String> = emptyList()

--- a/src/test/kotlin/cases/packageAnnotations/PrivateApi.kt
+++ b/src/test/kotlin/cases/packageAnnotations/PrivateApi.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package cases.packageAnnotations
+
+@PrivateApi
+annotation class PrivateApi

--- a/src/test/kotlin/cases/packageAnnotations/a/a/ShouldBeDeleted.kt
+++ b/src/test/kotlin/cases/packageAnnotations/a/a/ShouldBeDeleted.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package cases.packageAnnotations.a.a
+
+public class ShouldBeDeleted {
+}

--- a/src/test/kotlin/cases/packageAnnotations/a/b/ShouldBeDeleted.kt
+++ b/src/test/kotlin/cases/packageAnnotations/a/b/ShouldBeDeleted.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package cases.packageAnnotations.a.b
+
+public class ShouldBeDeleted {
+}

--- a/src/test/kotlin/cases/packageAnnotations/a/package-info.java
+++ b/src/test/kotlin/cases/packageAnnotations/a/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+@PrivateApi
+package cases.packageAnnotations.a;
+
+import cases.packageAnnotations.PrivateApi;

--- a/src/test/kotlin/cases/packageAnnotations/b/a/ShouldBeDeleted.kt
+++ b/src/test/kotlin/cases/packageAnnotations/b/a/ShouldBeDeleted.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package cases.packageAnnotations.b.a
+
+public class ShouldBeDeleted {
+}

--- a/src/test/kotlin/cases/packageAnnotations/b/a/package-info.java
+++ b/src/test/kotlin/cases/packageAnnotations/b/a/package-info.java
@@ -3,7 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
-@PrivateApi
+@PrivateApi @Deprecated
 package cases.packageAnnotations.b.a;
 
 import cases.packageAnnotations.PrivateApi;

--- a/src/test/kotlin/cases/packageAnnotations/b/a/package-info.java
+++ b/src/test/kotlin/cases/packageAnnotations/b/a/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+@PrivateApi
+package cases.packageAnnotations.b.a;
+
+import cases.packageAnnotations.PrivateApi;

--- a/src/test/kotlin/cases/packageAnnotations/b/b/ShouldRemainPublic.kt
+++ b/src/test/kotlin/cases/packageAnnotations/b/b/ShouldRemainPublic.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package cases.packageAnnotations.b.b
+
+public class ShouldRemainPublic {
+}

--- a/src/test/kotlin/cases/packageAnnotations/b/b/package-info.java
+++ b/src/test/kotlin/cases/packageAnnotations/b/b/package-info.java
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2016-2023 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package cases.packageAnnotations.b.b;

--- a/src/test/kotlin/cases/packageAnnotations/b/c/shouldRemainPublic.kt
+++ b/src/test/kotlin/cases/packageAnnotations/b/c/shouldRemainPublic.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package cases.packageAnnotations.b.c
+
+import cases.packageAnnotations.PrivateApi
+
+@PrivateApi
+interface `package-info` {
+}
+
+class ShouldNotBeRemoved

--- a/src/test/kotlin/cases/packageAnnotations/packageAnnotations.txt
+++ b/src/test/kotlin/cases/packageAnnotations/packageAnnotations.txt
@@ -2,3 +2,7 @@ public final class cases/packageAnnotations/b/b/ShouldRemainPublic {
 	public fun <init> ()V
 }
 
+public final class cases/packageAnnotations/b/c/ShouldNotBeRemoved {
+	public fun <init> ()V
+}
+

--- a/src/test/kotlin/cases/packageAnnotations/packageAnnotations.txt
+++ b/src/test/kotlin/cases/packageAnnotations/packageAnnotations.txt
@@ -1,0 +1,4 @@
+public final class cases/packageAnnotations/b/b/ShouldRemainPublic {
+	public fun <init> ()V
+}
+

--- a/src/test/kotlin/tests/CasesPublicAPITest.kt
+++ b/src/test/kotlin/tests/CasesPublicAPITest.kt
@@ -9,6 +9,11 @@ import kotlinx.validation.api.*
 import org.junit.*
 import org.junit.rules.TestName
 import java.io.File
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 
 class CasesPublicAPITest {
 
@@ -45,6 +50,8 @@ class CasesPublicAPITest {
 
     @Test fun nestedClasses() { snapshotAPIAndCompare(testName.methodName) }
 
+    @Test fun packageAnnotations() { snapshotAPIAndCompare(testName.methodName, setOf("cases/packageAnnotations/PrivateApi")) }
+
     @Test fun private() { snapshotAPIAndCompare(testName.methodName) }
 
     @Test fun protected() { snapshotAPIAndCompare(testName.methodName) }
@@ -59,11 +66,23 @@ class CasesPublicAPITest {
 
     private fun snapshotAPIAndCompare(testClassRelativePath: String, nonPublicMarkers: Set<String> = emptySet()) {
         val testClassPaths = baseClassPaths.map { it.resolve(testClassRelativePath) }
-        val testClasses = testClassPaths.flatMap { it.listFiles().orEmpty().asIterable() }
+        val testClasses = testClassPaths.flatMap {
+            if (!it.exists()) return@flatMap emptyList()
+            val allFiles = mutableListOf<File>()
+            Files.walkFileTree(it.toPath(), object : SimpleFileVisitor<Path>() {
+                override fun visitFile(file: Path?, attrs: BasicFileAttributes?): FileVisitResult {
+                    if (file != null) allFiles.add(file.toFile())
+                    return FileVisitResult.CONTINUE
+                }
+            })
+            allFiles
+        }
         check(testClasses.isNotEmpty()) { "No class files are found in paths: $testClassPaths" }
 
         val testClassStreams = testClasses.asSequence().filter { it.name.endsWith(".class") }.map { it.inputStream() }
-        val api = testClassStreams.loadApiFromJvmClasses().filterOutNonPublic().filterOutAnnotated(nonPublicMarkers)
+        val classes = testClassStreams.loadApiFromJvmClasses()
+        val additionalPackages = classes.extractAnnotatedPackages(nonPublicMarkers)
+        val api = classes.filterOutNonPublic(nonPublicPackages = additionalPackages).filterOutAnnotated(nonPublicMarkers)
         val target = baseOutputPath.resolve(testClassRelativePath).resolve(testName.methodName + ".txt")
         api.dumpAndCompareWith(target)
     }


### PR DESCRIPTION
Support extraction of packages annotated with particular annotations. These packages could be then be retained as public packages or filtered out as ignored packages.

Closes #156 