### PR TITLE
Update Kotlin version to 1.9.22

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-kotlin = "1.8.20"
+kotlin = "1.9.22"
 
 javaDiffUtils = "4.12"
 junit = "5.9.2"

--- a/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
@@ -13,7 +13,7 @@ import org.intellij.lang.annotations.Language
 public val API_DIR: String = ApiValidationExtension().apiDumpDirectory
 
 internal fun BaseKotlinGradleTest.test(
-    gradleVersion: String = "7.4.2",
+    gradleVersion: String = "8.5",
     injectPluginClasspath: Boolean = true,
     fn: BaseKotlinScope.() -> Unit
 ): GradleRunner {

--- a/src/functionalTest/resources/examples/gradle/base/multiplatformWithJvmTargets.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/base/multiplatformWithJvmTargets.gradle.kts
@@ -21,6 +21,9 @@ kotlin {
             testRuns["test"].executionTask.configure {
                 useJUnit()
             }
+            attributes {
+                attribute(Attribute.of("variant", String::class.java), "a")
+            }
         }
         jvm("anotherJvm") {
             compilations.all {
@@ -28,6 +31,9 @@ kotlin {
             }
             testRuns["test"].executionTask.configure {
                 useJUnit()
+            }
+            attributes {
+                attribute(Attribute.of("variant", String::class.java), "b")
             }
         }
     }


### PR DESCRIPTION
As part of KLib support (#149) we need to bump the Kotlin version as the required API is only available starting from the 1.9.20.