### PR TITLE
Correctly handle compilations without sources

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/api/Assert.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/Assert.kt
@@ -24,6 +24,13 @@ internal fun BuildResult.assertTaskFailure(task: String) {
     assertTaskOutcome(TaskOutcome.FAILED, task)
 }
 
+/**
+ * Helper `fun` for asserting a [TaskOutcome] to be equal to [TaskOutcome.SKIPPED]
+ */
+internal fun BuildResult.assertTaskSkipped(task: String) {
+    assertTaskOutcome(TaskOutcome.SKIPPED, task)
+}
+
 private fun BuildResult.assertTaskOutcome(taskOutcome: TaskOutcome, taskName: String) {
     assertEquals(taskOutcome, task(taskName)?.outcome)
 }

--- a/src/functionalTest/kotlin/kotlinx/validation/test/KlibVerificationTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/KlibVerificationTests.kt
@@ -18,6 +18,7 @@ import org.junit.Test
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 internal const val BANNED_TARGETS_PROPERTY_NAME = "binary.compatibility.validator.klib.targets.disabled.for.testing"
@@ -632,5 +633,40 @@ internal class KlibVerificationTests : BaseKotlinGradleTest() {
                         "androidNativeX86, linuxArm64.linux, linuxX64, mingwX64]"
             )
         }
+    }
+
+    @Test
+    fun `apiDump should not fail for empty project`() {
+        val runner = test {
+            baseProjectSetting()
+            addToSrcSet("/examples/classes/AnotherBuildConfig.kt", sourceSet = "commonTest")
+            runApiDump()
+        }
+
+        runner.build().apply {
+            assertTaskSkipped(":klibApiDump")
+        }
+        assertFalse(runner.projectDir.resolve("api").exists())
+    }
+
+    @Test
+    fun `apiDump should not fail if there is only one target`() {
+        val runner = test {
+            baseProjectSetting()
+            addToSrcSet("/examples/classes/AnotherBuildConfig.kt", sourceSet = "commonTest")
+            addToSrcSet("/examples/classes/AnotherBuildConfig.kt", sourceSet = "linuxX64Main")
+            runApiDump()
+        }
+        checkKlibDump(runner.build(), "/examples/classes/AnotherBuildConfig.klib.linuxX64Only.dump")
+    }
+
+    @Test
+    fun `apiCheck should not fail for empty project`() {
+        val runner = test {
+            baseProjectSetting()
+            addToSrcSet("/examples/classes/AnotherBuildConfig.kt", sourceSet = "commonTest")
+            runApiCheck()
+        }
+        runner.build()
     }
 }

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.linuxX64Only.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.linuxX64Only.dump
@@ -1,0 +1,14 @@
+// Klib ABI Dump
+// Targets: [linuxX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <testproject>
+final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
+    constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+    final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
+    final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
+        final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+}

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -10,8 +10,8 @@ import kotlinx.validation.api.klib.konanTargetNameMapping
 import org.gradle.api.*
 import org.gradle.api.plugins.*
 import org.gradle.api.provider.*
+import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.*
-import org.jetbrains.kotlin.cli.jvm.main
 import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
@@ -473,7 +473,13 @@ private class KlibValidationPipelineBuilder(
                 "into a single merged KLib ABI dump"
         dumpFileName = klibDumpFileName
         mergedFile = klibMergeDir.resolve(klibDumpFileName)
-        compilableTargets = project.compilableTargets()
+        val compilableTargets = project.compilableTargets()
+        filterTargets(Spec<String> {
+                name -> compilableTargets.get()
+            .map(KlibTarget::parse)
+            .map { it.configurableName }
+            .contains(name)
+        })
         onlyIf {
             compilableTargets.get().isNotEmpty()
         }
@@ -488,7 +494,13 @@ private class KlibValidationPipelineBuilder(
                 "different targets into a single merged KLib ABI dump"
         dumpFileName = klibDumpFileName
         mergedFile = klibMergeDir.resolve(klibDumpFileName)
-        compilableTargets = project.compilableTargets()
+        val compilableTargets = project.compilableTargets()
+        filterTargets(Spec<String> {
+            name -> compilableTargets.get()
+                .map(KlibTarget::parse)
+                .map { it.configurableName }
+                .contains(name)
+        })
         onlyIf {
             compilableTargets.get().isNotEmpty()
         }

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -473,9 +473,6 @@ private class KlibValidationPipelineBuilder(
                 "into a single merged KLib ABI dump"
         dumpFileName = klibDumpFileName
         mergedFile = klibMergeDir.resolve(klibDumpFileName)
-        // At task configuration time, we don't know if a target will produce any artifacts,
-        // so we initialize it with all possible inputs and then filter them out during merge.
-        filterTargets(project.isTargetWithConfigurableNameCompilable())
         val compilableTargets = project.compilableTargets()
         onlyIf("There are no dumps to merge") {
             compilableTargets.get().isNotEmpty()
@@ -491,9 +488,6 @@ private class KlibValidationPipelineBuilder(
                 "different targets into a single merged KLib ABI dump"
         dumpFileName = klibDumpFileName
         mergedFile = klibMergeDir.resolve(klibDumpFileName)
-        // At task configuration time, we don't know if a target will produce any artifacts,
-        // so we initialize it with all possible inputs and then filter them out during merge.
-        filterTargets(project.isTargetWithConfigurableNameCompilable())
         val compilableTargets = project.compilableTargets()
         onlyIf("There are no dumps to merge") {
             compilableTargets.get().isNotEmpty()

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -417,7 +417,7 @@ private class KlibValidationPipelineBuilder(
                 project.name
         projectApiFile = klibApiDir.get().resolve(klibDumpFileName)
         generatedApiFile = klibMergeDir.resolve(klibDumpFileName)
-        val hasCompilableTargets = project.compilableTargetsPredicate()
+        val hasCompilableTargets = project.hasCompilableTargetsPredicate()
         onlyIf("There are no klibs compiled for the project") { hasCompilableTargets.get() }
     }
 
@@ -431,7 +431,7 @@ private class KlibValidationPipelineBuilder(
         group = "other"
         from = klibMergeDir.resolve(klibDumpFileName)
         to = klibApiDir.get().resolve(klibDumpFileName)
-        val hasCompilableTargets = project.compilableTargetsPredicate()
+        val hasCompilableTargets = project.hasCompilableTargetsPredicate()
         onlyIf("There are no klibs compiled for the project") { hasCompilableTargets.get() }
     }
 
@@ -451,7 +451,7 @@ private class KlibValidationPipelineBuilder(
         supportedTargets = supportedTargets()
         inputAbiFile = klibApiDir.get().resolve(klibDumpFileName)
         outputAbiFile = klibOutputDir.resolve(klibDumpFileName)
-        val hasCompilableTargets = project.compilableTargetsPredicate()
+        val hasCompilableTargets = project.hasCompilableTargetsPredicate()
         onlyIf("There are no klibs compiled for the project") { hasCompilableTargets.get() }
     }
 
@@ -468,7 +468,7 @@ private class KlibValidationPipelineBuilder(
                 "into a single merged KLib ABI dump"
         dumpFileName = klibDumpFileName
         mergedFile = klibMergeDir.resolve(klibDumpFileName)
-        val hasCompilableTargets = project.compilableTargetsPredicate()
+        val hasCompilableTargets = project.hasCompilableTargetsPredicate()
         onlyIf("There are no dumps to merge") { hasCompilableTargets.get() }
     }
 
@@ -481,7 +481,7 @@ private class KlibValidationPipelineBuilder(
                 "different targets into a single merged KLib ABI dump"
         dumpFileName = klibDumpFileName
         mergedFile = klibMergeDir.resolve(klibDumpFileName)
-        val hasCompilableTargets = project.compilableTargetsPredicate()
+        val hasCompilableTargets = project.hasCompilableTargetsPredicate()
         onlyIf("There are no dumps to merge") { hasCompilableTargets.get() }
     }
 
@@ -585,7 +585,7 @@ private class KlibValidationPipelineBuilder(
     }
 
     // Returns a predicate that checks if there are any compilable targets
-    private fun Project.compilableTargetsPredicate(): Provider<Boolean> {
+    private fun Project.hasCompilableTargetsPredicate(): Provider<Boolean> {
         return project.provider {
             project.kotlinMultiplatform.targets.matching { it.emitsKlib }
                 .asSequence()

--- a/src/main/kotlin/KotlinKlibMergeAbiTask.kt
+++ b/src/main/kotlin/KotlinKlibMergeAbiTask.kt
@@ -8,7 +8,6 @@ package kotlinx.validation
 import kotlinx.validation.api.klib.KlibDump
 import kotlinx.validation.api.klib.saveTo
 import org.gradle.api.DefaultTask
-import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.*
 import java.io.File
 
@@ -46,24 +45,18 @@ internal abstract class KotlinKlibMergeAbiTask : DefaultTask() {
     @Input
     lateinit var dumpFileName: String
 
-    private var targetPredicate: Spec<String> = Spec<String> { true }
-
     internal fun addInput(target: String, file: File) {
         targetToFile[target] = file
-    }
-
-    internal fun filterTargets(filter: Spec<String>) {
-        targetPredicate = filter
     }
 
     @OptIn(ExperimentalBCVApi::class)
     @TaskAction
     internal fun merge() {
-        val filter = targetPredicate
         KlibDump().apply {
             targetToFile.forEach { (targetName, dumpDir) ->
-                if (filter.isSatisfiedBy(targetName)) {
-                    merge(dumpDir.resolve(dumpFileName), targetName)
+                val dumpFile = dumpDir.resolve(dumpFileName)
+                if (dumpFile.exists()) {
+                    merge(dumpFile, targetName)
                 }
             }
         }.saveTo(mergedFile)


### PR DESCRIPTION
BCV's Klib-validation part does not handle compilations without any sources properly, as a result tasks manipulating dumps might expect a dump for a target that doesn't have any compiled klibs.

Such targets/compilations occur when, for example, a project consists only of test sources.

Verified the fix locally using both projects mentioned in the original bug report. 

Fixes #199 