### PR TITLE
Check source sets existence for Klib dump tasks only after compilation

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/api/TestDsl.kt
@@ -148,8 +148,8 @@ internal fun FileContainer.emptyApiFile(projectName: String) {
     apiFile(projectName) {}
 }
 
-internal fun BaseKotlinScope.runner(fn: Runner.() -> Unit) {
-    val runner = Runner()
+internal fun BaseKotlinScope.runner(withConfigurationCache: Boolean = true, fn: Runner.() -> Unit) {
+    val runner = Runner(withConfigurationCache)
     fn(runner)
 
     this.runner = runner
@@ -188,9 +188,9 @@ internal class AppendableScope(val filePath: String) {
     val files: MutableList<String> = mutableListOf()
 }
 
-internal class Runner {
+internal class Runner(withConfigurationCache: Boolean = true) {
     val arguments: MutableList<String> = mutableListOf<String>().apply {
-        if (!koverEnabled) {
+        if (!koverEnabled && withConfigurationCache) {
             // Configuration cache is incompatible with javaagents being enabled for Gradle
             // See https://github.com/gradle/gradle/issues/25979
             add("--configuration-cache")

--- a/src/functionalTest/kotlin/kotlinx/validation/test/KlibVerificationTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/KlibVerificationTests.kt
@@ -669,4 +669,33 @@ internal class KlibVerificationTests : BaseKotlinGradleTest() {
         }
         runner.build()
     }
+
+    @Test
+    fun `apiDump for a project with generated sources only`() {
+        val runner = test {
+            baseProjectSetting()
+            additionalBuildConfig("/examples/gradle/configuration/generatedSources/generatedSources.gradle.kts")
+            // TODO: enable configuration cache back when we start skipping tasks correctly
+            runner(withConfigurationCache = false) {
+                arguments.add(":apiDump")
+            }
+        }
+        checkKlibDump(runner.build(), "/examples/classes/GeneratedSources.klib.dump")
+    }
+
+    @Test
+    fun `apiCheck for a project with generated sources only`() {
+        val runner = test {
+            baseProjectSetting()
+            additionalBuildConfig("/examples/gradle/configuration/generatedSources/generatedSources.gradle.kts")
+            abiFile(projectName = "testproject") {
+                resolve("/examples/classes/GeneratedSources.klib.dump")
+            }
+            // TODO: enable configuration cache back when we start skipping tasks correctly
+            runner(withConfigurationCache = false) {
+                arguments.add(":apiCheck")
+            }
+        }
+        assertApiCheckPassed(runner.build())
+    }
 }

--- a/src/functionalTest/resources/examples/classes/GeneratedSources.klib.dump
+++ b/src/functionalTest/resources/examples/classes/GeneratedSources.klib.dump
@@ -1,0 +1,12 @@
+// Klib ABI Dump
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, linuxArm64, linuxX64, mingwX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <testproject>
+final class /Generated { // /Generated|null[0]
+    constructor <init>() // /Generated.<init>|<init>(){}[0]
+    final fun helloCreator(): kotlin/Int // /Generated.helloCreator|helloCreator(){}[0]
+}

--- a/src/functionalTest/resources/examples/gradle/configuration/generatedSources/generatedSources.gradle.kts
+++ b/src/functionalTest/resources/examples/gradle/configuration/generatedSources/generatedSources.gradle.kts
@@ -1,0 +1,22 @@
+abstract class GenerateSourcesTask : org.gradle.api.DefaultTask() {
+    @get:org.gradle.api.tasks.OutputDirectory
+    abstract val outputDirectory: org.gradle.api.file.DirectoryProperty
+
+    @org.gradle.api.tasks.TaskAction
+    fun generate() {
+        outputDirectory.asFile.get().mkdirs()
+        outputDirectory.file("Generated.kt").get().asFile.writeText("""
+                        public class Generated { public fun helloCreator(): Int = 42 }
+                    """.trimIndent())
+    }
+}
+
+val srcgen = project.tasks.register("generateSources", GenerateSourcesTask::class.java)
+srcgen.configure {
+    outputDirectory.set(project.layout.buildDirectory.get().dir("generated").dir("kotlin"))
+}
+
+val kotlin = project.extensions.getByType(org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension::class.java)
+kotlin.sourceSets.getByName("commonMain") {
+    kotlin.srcDir(srcgen)
+}

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -398,9 +398,16 @@ private class KlibValidationPipelineBuilder(
         commonApiCheck.configure { it.dependsOn(klibCheck) }
 
         klibDump.configure { it.dependsOn(klibMergeInferred) }
+        // Extraction task depends on supportedTargets() provider which returns a set of targets supported
+        // by the host compiler and having some sources. A set of sources for a target may change until the actual
+        // klib compilation will take place, so we may observe incorrect value if check source sets earlier.
+        // Merge task already depends on compilations, so instead of adding each compilation task to the extraction's
+        // dependency set, we can depend on the merge task itself.
+        klibExtractAbiForSupportedTargets.configure {
+            it.dependsOn(klibMerge)
+        }
         klibCheck.configure {
             it.dependsOn(klibExtractAbiForSupportedTargets)
-            it.dependsOn(klibMerge)
         }
 
         project.configureTargets(klibApiDir, klibMerge, klibMergeInferred)


### PR DESCRIPTION
Source sets may not be final until klib compilation. Dependencies between tasks were updated so that all tasks relying on that info are executed only after klib compilation.

This fix does not solve #209, it will be addressed separately.

Fixes #206 
