### PR TITLE
Add more vertical spacing to KLib dumps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.dump  text eol=lf

--- a/src/functionalTest/kotlin/kotlinx/validation/test/KlibVerificationTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/KlibVerificationTests.kt
@@ -358,6 +358,28 @@ internal class KlibVerificationTests : BaseKotlinGradleTest() {
     }
 
     @Test
+    fun `check sorting for target-specific declarations`() {
+        val runner = test {
+            baseProjectSetting()
+            addToSrcSet("/examples/classes/TopLevelDeclarations.kt")
+            addToSrcSet("/examples/classes/TopLevelDeclarationsExp.kt")
+            addToSrcSet("/examples/classes/TopLevelDeclarationsLinuxOnly.kt", "linuxMain")
+            addToSrcSet("/examples/classes/TopLevelDeclarationsMingwOnly.kt", "mingwMain")
+            addToSrcSet("/examples/classes/TopLevelDeclarationsAndroidOnly.kt", "androidNativeMain")
+
+
+            runner {
+                arguments.add(":klibApiDump")
+            }
+        }
+
+        checkKlibDump(
+            runner.build(), "/examples/classes/TopLevelDeclarations.klib.diverging.dump",
+            dumpTask = ":klibApiDump"
+        )
+    }
+
+    @Test
     fun `infer a dump for a target with custom name`() {
         val runner = test {
             settingsGradleKts {

--- a/src/functionalTest/kotlin/kotlinx/validation/test/KlibVerificationTests.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/KlibVerificationTests.kt
@@ -36,7 +36,7 @@ private fun KlibVerificationTests.checkKlibDump(
 
     val expected = readFileList(expectedDumpFileName)
 
-    Assertions.assertThat(generatedDump.readText()).isEqualToIgnoringNewLines(expected)
+    Assertions.assertThat(generatedDump.readText()).isEqualTo(expected)
 }
 
 internal class KlibVerificationTests : BaseKotlinGradleTest() {
@@ -155,7 +155,7 @@ internal class KlibVerificationTests : BaseKotlinGradleTest() {
             assertTrue(jvmApiDump.exists(), "No API dump for JVM")
 
             val jvmExpected = readFileList("/examples/classes/AnotherBuildConfig.dump")
-            Assertions.assertThat(jvmApiDump.readText()).isEqualToIgnoringNewLines(jvmExpected)
+            Assertions.assertThat(jvmApiDump.readText()).isEqualTo(jvmExpected)
         }
     }
 

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.clash.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.clash.dump
@@ -9,9 +9,12 @@
 // Library unique name: <testproject>
 final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
     constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+
     final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
         final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+
     final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
 }
+
 // Targets: [linux]
 final fun (org.different.pack/BuildConfig).org.different.pack/linuxArm64Specific(): kotlin/Int // org.different.pack/linuxArm64Specific|linuxArm64Specific@org.different.pack.BuildConfig(){}[0]

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.custom.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.custom.dump
@@ -8,7 +8,9 @@
 // Library unique name: <testproject>
 final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
     constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+
     final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
         final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+
     final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
 }

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.dump
@@ -8,7 +8,9 @@
 // Library unique name: <testproject>
 final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
     constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+
     final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
         final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+
     final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
 }

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.linuxX64Only.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.linuxX64Only.dump
@@ -8,7 +8,9 @@
 // Library unique name: <testproject>
 final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
     constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+
     final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
         final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+
     final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
 }

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.renamedTarget.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.renamedTarget.dump
@@ -8,7 +8,9 @@
 // Library unique name: <testproject>
 final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
     constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
-    final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
+
     final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
         final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+
+    final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
 }

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.web.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfig.klib.web.dump
@@ -8,7 +8,9 @@
 // Library unique name: <testproject>
 final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
     constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+
     final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
         final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+
     final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
 }

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfigLinux.klib.grouping.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfigLinux.klib.grouping.dump
@@ -9,9 +9,12 @@
 // Library unique name: <testproject>
 final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
     constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+
     final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
         final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+
     final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
 }
+
 // Targets: [linux]
 final fun (org.different.pack/BuildConfig).org.different.pack/linuxArm64Specific(): kotlin/Int // org.different.pack/linuxArm64Specific|linuxArm64Specific@org.different.pack.BuildConfig(){}[0]

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfigLinuxArm64Extra.klib.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfigLinuxArm64Extra.klib.dump
@@ -8,9 +8,12 @@
 // Library unique name: <testproject>
 final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
     constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+
     final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
         final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+
     final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
 }
+
 // Targets: [linuxArm64]
 final fun (org.different.pack/BuildConfig).org.different.pack/linuxArm64Specific(): kotlin/Int // org.different.pack/linuxArm64Specific|linuxArm64Specific@org.different.pack.BuildConfig(){}[0]

--- a/src/functionalTest/resources/examples/classes/AnotherBuildConfigModified.klib.dump
+++ b/src/functionalTest/resources/examples/classes/AnotherBuildConfigModified.klib.dump
@@ -8,8 +8,10 @@
 // Library unique name: <testproject>
 final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
     constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+
     final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
         final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+
     final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
     final fun f2(): kotlin/Int // org.different.pack/BuildConfig.f2|f2(){}[0]
 }

--- a/src/functionalTest/resources/examples/classes/ClassWithPublicMarkers.klib.dump
+++ b/src/functionalTest/resources/examples/classes/ClassWithPublicMarkers.klib.dump
@@ -10,20 +10,26 @@
 // Library unique name: <testproject>
 final class foo.api/ClassInPublicPackage { // foo.api/ClassInPublicPackage|null[0]
     constructor <init>() // foo.api/ClassInPublicPackage.<init>|<init>(){}[0]
+
     final class Inner { // foo.api/ClassInPublicPackage.Inner|null[0]
         constructor <init>() // foo.api/ClassInPublicPackage.Inner.<init>|<init>(){}[0]
     }
 }
+
 final class foo/ClassWithPublicMarkers { // foo/ClassWithPublicMarkers|null[0]
     constructor <init>() // foo/ClassWithPublicMarkers.<init>|<init>(){}[0]
+
     final class MarkedClass { // foo/ClassWithPublicMarkers.MarkedClass|null[0]
         constructor <init>() // foo/ClassWithPublicMarkers.MarkedClass.<init>|<init>(){}[0]
+
         final val bar1 // foo/ClassWithPublicMarkers.MarkedClass.bar1|{}bar1[0]
             final fun <get-bar1>(): kotlin/Int // foo/ClassWithPublicMarkers.MarkedClass.bar1.<get-bar1>|<get-bar1>(){}[0]
     }
+
     final class NotMarkedClass { // foo/ClassWithPublicMarkers.NotMarkedClass|null[0]
         constructor <init>() // foo/ClassWithPublicMarkers.NotMarkedClass.<init>|<init>(){}[0]
     }
+
     final var bar1 // foo/ClassWithPublicMarkers.bar1|{}bar1[0]
         final fun <get-bar1>(): kotlin/Int // foo/ClassWithPublicMarkers.bar1.<get-bar1>|<get-bar1>(){}[0]
         final fun <set-bar1>(kotlin/Int) // foo/ClassWithPublicMarkers.bar1.<set-bar1>|<set-bar1>(kotlin.Int){}[0]
@@ -34,12 +40,15 @@ final class foo/ClassWithPublicMarkers { // foo/ClassWithPublicMarkers|null[0]
         final fun <get-notMarkedPublic>(): kotlin/Int // foo/ClassWithPublicMarkers.notMarkedPublic.<get-notMarkedPublic>|<get-notMarkedPublic>(){}[0]
         final fun <set-notMarkedPublic>(kotlin/Int) // foo/ClassWithPublicMarkers.notMarkedPublic.<set-notMarkedPublic>|<set-notMarkedPublic>(kotlin.Int){}[0]
 }
+
 open annotation class foo/PublicClass : kotlin/Annotation { // foo/PublicClass|null[0]
     constructor <init>() // foo/PublicClass.<init>|<init>(){}[0]
 }
+
 open annotation class foo/PublicField : kotlin/Annotation { // foo/PublicField|null[0]
     constructor <init>() // foo/PublicField.<init>|<init>(){}[0]
 }
+
 open annotation class foo/PublicProperty : kotlin/Annotation { // foo/PublicProperty|null[0]
     constructor <init>() // foo/PublicProperty.<init>|<init>(){}[0]
 }

--- a/src/functionalTest/resources/examples/classes/GeneratedSources.klib.dump
+++ b/src/functionalTest/resources/examples/classes/GeneratedSources.klib.dump
@@ -8,5 +8,6 @@
 // Library unique name: <testproject>
 final class /Generated { // /Generated|null[0]
     constructor <init>() // /Generated.<init>|<init>(){}[0]
+
     final fun helloCreator(): kotlin/Int // /Generated.helloCreator|helloCreator(){}[0]
 }

--- a/src/functionalTest/resources/examples/classes/Properties.klib.dump
+++ b/src/functionalTest/resources/examples/classes/Properties.klib.dump
@@ -9,9 +9,11 @@
 final class foo/ClassWithProperties { // foo/ClassWithProperties|null[0]
     constructor <init>() // foo/ClassWithProperties.<init>|<init>(){}[0]
 }
+
 open annotation class foo/HiddenField : kotlin/Annotation { // foo/HiddenField|null[0]
     constructor <init>() // foo/HiddenField.<init>|<init>(){}[0]
 }
+
 open annotation class foo/HiddenProperty : kotlin/Annotation { // foo/HiddenProperty|null[0]
     constructor <init>() // foo/HiddenProperty.<init>|<init>(){}[0]
 }

--- a/src/functionalTest/resources/examples/classes/Subclasses.klib.dump
+++ b/src/functionalTest/resources/examples/classes/Subclasses.klib.dump
@@ -8,6 +8,7 @@
 // Library unique name: <testproject>
 final class subclasses/A { // subclasses/A|null[0]
     constructor <init>() // subclasses/A.<init>|<init>(){}[0]
+
     final class D { // subclasses/A.D|null[0]
         constructor <init>() // subclasses/A.D.<init>|<init>(){}[0]
     }

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.all.dump
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.all.dump
@@ -9,90 +9,120 @@
 open annotation class examples.classes/A : kotlin/Annotation { // examples.classes/A|null[0]
     constructor <init>() // examples.classes/A.<init>|<init>(){}[0]
 }
+
 open annotation class examples.classes/AA : kotlin/Annotation { // examples.classes/AA|null[0]
     constructor <init>() // examples.classes/AA.<init>|<init>(){}[0]
 }
+
 open annotation class examples.classes/AAA : kotlin/Annotation { // examples.classes/AAA|null[0]
     constructor <init>() // examples.classes/AAA.<init>|<init>(){}[0]
 }
+
 final enum class examples.classes/E : kotlin/Enum<examples.classes/E> { // examples.classes/E|null[0]
     enum entry A // examples.classes/E.A|null[0]
     enum entry B // examples.classes/E.B|null[0]
     enum entry C // examples.classes/E.C|null[0]
+
     final val entries // examples.classes/E.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/E> // examples.classes/E.entries.<get-entries>|<get-entries>#static(){}[0]
+
     final fun valueOf(kotlin/String): examples.classes/E // examples.classes/E.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<examples.classes/E> // examples.classes/E.values|values#static(){}[0]
 }
+
 final enum class examples.classes/EE : kotlin/Enum<examples.classes/EE> { // examples.classes/EE|null[0]
     enum entry AA // examples.classes/EE.AA|null[0]
     enum entry BB // examples.classes/EE.BB|null[0]
     enum entry CC // examples.classes/EE.CC|null[0]
+
     final val entries // examples.classes/EE.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/EE> // examples.classes/EE.entries.<get-entries>|<get-entries>#static(){}[0]
+
     final fun valueOf(kotlin/String): examples.classes/EE // examples.classes/EE.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<examples.classes/EE> // examples.classes/EE.values|values#static(){}[0]
 }
+
 abstract fun interface examples.classes/FI { // examples.classes/FI|null[0]
     abstract fun a() // examples.classes/FI.a|a(){}[0]
 }
+
 abstract interface examples.classes/I // examples.classes/I|null[0]
+
 abstract interface examples.classes/II // examples.classes/II|null[0]
+
 abstract class examples.classes/AC { // examples.classes/AC|null[0]
     constructor <init>() // examples.classes/AC.<init>|<init>(){}[0]
+
     abstract fun a() // examples.classes/AC.a|a(){}[0]
     final fun b() // examples.classes/AC.b|b(){}[0]
 }
+
 final class examples.classes/C { // examples.classes/C|null[0]
     constructor <init>(kotlin/Any) // examples.classes/C.<init>|<init>(kotlin.Any){}[0]
+
     final val v // examples.classes/C.v|{}v[0]
         final fun <get-v>(): kotlin/Any // examples.classes/C.v.<get-v>|<get-v>(){}[0]
+
     final fun m() // examples.classes/C.m|m(){}[0]
 }
+
 final class examples.classes/D { // examples.classes/D|null[0]
     constructor <init>(kotlin/Int) // examples.classes/D.<init>|<init>(kotlin.Int){}[0]
+
     final val x // examples.classes/D.x|{}x[0]
         final fun <get-x>(): kotlin/Int // examples.classes/D.x.<get-x>|<get-x>(){}[0]
+
     final fun component1(): kotlin/Int // examples.classes/D.component1|component1(){}[0]
     final fun copy(kotlin/Int =...): examples.classes/D // examples.classes/D.copy|copy(kotlin.Int){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // examples.classes/D.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // examples.classes/D.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // examples.classes/D.toString|toString(){}[0]
 }
+
 final class examples.classes/IC : examples.classes/II { // examples.classes/IC|null[0]
     constructor <init>() // examples.classes/IC.<init>|<init>(){}[0]
 }
+
 final class examples.classes/Outer { // examples.classes/Outer|null[0]
     constructor <init>() // examples.classes/Outer.<init>|<init>(){}[0]
+
     final class Nested { // examples.classes/Outer.Nested|null[0]
         constructor <init>() // examples.classes/Outer.Nested.<init>|<init>(){}[0]
+
         final enum class NE : kotlin/Enum<examples.classes/Outer.Nested.NE> { // examples.classes/Outer.Nested.NE|null[0]
             enum entry A // examples.classes/Outer.Nested.NE.A|null[0]
             enum entry B // examples.classes/Outer.Nested.NE.B|null[0]
             enum entry C // examples.classes/Outer.Nested.NE.C|null[0]
+
             final val entries // examples.classes/Outer.Nested.NE.entries|#static{}entries[0]
                 final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.entries.<get-entries>|<get-entries>#static(){}[0]
+
             final fun valueOf(kotlin/String): examples.classes/Outer.Nested.NE // examples.classes/Outer.Nested.NE.valueOf|valueOf#static(kotlin.String){}[0]
             final fun values(): kotlin/Array<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.values|values#static(){}[0]
         }
+
         final inner class Inner { // examples.classes/Outer.Nested.Inner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.Inner.<init>|<init>(){}[0]
         }
+
         final inner class YetAnotherInner { // examples.classes/Outer.Nested.YetAnotherInner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.YetAnotherInner.<init>|<init>(){}[0]
         }
     }
 }
+
 open class examples.classes/OC { // examples.classes/OC|null[0]
     constructor <init>(kotlin/Int) // examples.classes/OC.<init>|<init>(kotlin.Int){}[0]
     constructor <init>(kotlin/Long) // examples.classes/OC.<init>|<init>(kotlin.Long){}[0]
     constructor <init>(kotlin/String) // examples.classes/OC.<init>|<init>(kotlin.String){}[0]
+
     final val ix // examples.classes/OC.ix|{}ix[0]
         final fun <get-ix>(): kotlin/Int // examples.classes/OC.ix.<get-ix>|<get-ix>(){}[0]
     final val iy // examples.classes/OC.iy|{}iy[0]
         final fun <get-iy>(): kotlin/Long // examples.classes/OC.iy.<get-iy>|<get-iy>(){}[0]
     final val iz // examples.classes/OC.iz|{}iz[0]
         final fun <get-iz>(): kotlin/String // examples.classes/OC.iz.<get-iz>|<get-iz>(){}[0]
+
     final var x // examples.classes/OC.x|{}x[0]
         final fun <get-x>(): kotlin/Int // examples.classes/OC.x.<get-x>|<get-x>(){}[0]
         final fun <set-x>(kotlin/Int) // examples.classes/OC.x.<set-x>|<set-x>(kotlin.Int){}[0]
@@ -102,27 +132,34 @@ open class examples.classes/OC { // examples.classes/OC|null[0]
     final var z // examples.classes/OC.z|{}z[0]
         final fun <get-z>(): kotlin/Int // examples.classes/OC.z.<get-z>|<get-z>(){}[0]
         final fun <set-z>(kotlin/Int) // examples.classes/OC.z.<set-z>|<set-z>(kotlin.Int){}[0]
+
     final fun c() // examples.classes/OC.c|c(){}[0]
     open fun o(): kotlin/Int // examples.classes/OC.o|o(){}[0]
 }
+
 final object examples.classes/O // examples.classes/O|null[0]
+
 final object examples.classes/OO // examples.classes/OO|null[0]
+
 final const val examples.classes/con // examples.classes/con|{}con[0]
     final fun <get-con>(): kotlin/String // examples.classes/con.<get-con>|<get-con>(){}[0]
 final const val examples.classes/intCon // examples.classes/intCon|{}intCon[0]
     final fun <get-intCon>(): kotlin/Int // examples.classes/intCon.<get-intCon>|<get-intCon>(){}[0]
+
 final val examples.classes/a // examples.classes/a|{}a[0]
     final fun <get-a>(): kotlin/Any // examples.classes/a.<get-a>|<get-a>(){}[0]
 final val examples.classes/i // examples.classes/i|{}i[0]
     final fun <get-i>(): kotlin/Int // examples.classes/i.<get-i>|<get-i>(){}[0]
 final val examples.classes/l // examples.classes/l|{}l[0]
     final fun <get-l>(): kotlin/Long // examples.classes/l.<get-l>|<get-l>(){}[0]
+
 final var examples.classes/d // examples.classes/d|{}d[0]
     final fun <get-d>(): kotlin/Double // examples.classes/d.<get-d>|<get-d>(){}[0]
     final fun <set-d>(kotlin/Double) // examples.classes/d.<set-d>|<set-d>(kotlin.Double){}[0]
 final var examples.classes/r // examples.classes/r|{}r[0]
     final fun <get-r>(): kotlin/Float // examples.classes/r.<get-r>|<get-r>(){}[0]
     final fun <set-r>(kotlin/Float) // examples.classes/r.<set-r>|<set-r>(kotlin.Float){}[0]
+
 final fun <#A: kotlin/Any?> examples.classes/consume(#A) // examples.classes/consume|consume(0:0){0§<kotlin.Any?>}[0]
 final fun examples.classes/testFun(): kotlin/Int // examples.classes/testFun|testFun(){}[0]
 final inline fun examples.classes/testInlineFun() // examples.classes/testInlineFun|testInlineFun(){}[0]

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.diverging.dump
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.diverging.dump
@@ -1,0 +1,238 @@
+// Klib ABI Dump
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, linuxArm64, linuxX64, mingwX64]
+// Alias: androidNative => [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86]
+// Alias: linux => [linuxArm64, linuxX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <testproject>
+open annotation class examples.classes/A : kotlin/Annotation { // examples.classes/A|null[0]
+    constructor <init>() // examples.classes/A.<init>|<init>(){}[0]
+}
+
+open annotation class examples.classes/AA : kotlin/Annotation { // examples.classes/AA|null[0]
+    constructor <init>() // examples.classes/AA.<init>|<init>(){}[0]
+}
+
+open annotation class examples.classes/AAA : kotlin/Annotation { // examples.classes/AAA|null[0]
+    constructor <init>() // examples.classes/AAA.<init>|<init>(){}[0]
+}
+
+final enum class examples.classes/E : kotlin/Enum<examples.classes/E> { // examples.classes/E|null[0]
+    enum entry A // examples.classes/E.A|null[0]
+    enum entry B // examples.classes/E.B|null[0]
+    enum entry C // examples.classes/E.C|null[0]
+
+    final val entries // examples.classes/E.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/E> // examples.classes/E.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): examples.classes/E // examples.classes/E.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<examples.classes/E> // examples.classes/E.values|values#static(){}[0]
+}
+
+final enum class examples.classes/EE : kotlin/Enum<examples.classes/EE> { // examples.classes/EE|null[0]
+    enum entry AA // examples.classes/EE.AA|null[0]
+    enum entry BB // examples.classes/EE.BB|null[0]
+    enum entry CC // examples.classes/EE.CC|null[0]
+
+    final val entries // examples.classes/EE.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/EE> // examples.classes/EE.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): examples.classes/EE // examples.classes/EE.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<examples.classes/EE> // examples.classes/EE.values|values#static(){}[0]
+}
+
+abstract fun interface examples.classes/FI { // examples.classes/FI|null[0]
+    abstract fun a() // examples.classes/FI.a|a(){}[0]
+}
+
+abstract interface examples.classes/I // examples.classes/I|null[0]
+
+abstract interface examples.classes/II // examples.classes/II|null[0]
+
+abstract class examples.classes/AC { // examples.classes/AC|null[0]
+    constructor <init>() // examples.classes/AC.<init>|<init>(){}[0]
+
+    abstract fun a() // examples.classes/AC.a|a(){}[0]
+    final fun b() // examples.classes/AC.b|b(){}[0]
+}
+
+final class examples.classes/C { // examples.classes/C|null[0]
+    constructor <init>(kotlin/Any) // examples.classes/C.<init>|<init>(kotlin.Any){}[0]
+
+    final val v // examples.classes/C.v|{}v[0]
+        final fun <get-v>(): kotlin/Any // examples.classes/C.v.<get-v>|<get-v>(){}[0]
+
+    final fun m() // examples.classes/C.m|m(){}[0]
+}
+
+final class examples.classes/D { // examples.classes/D|null[0]
+    constructor <init>(kotlin/Int) // examples.classes/D.<init>|<init>(kotlin.Int){}[0]
+
+    final val x // examples.classes/D.x|{}x[0]
+        final fun <get-x>(): kotlin/Int // examples.classes/D.x.<get-x>|<get-x>(){}[0]
+
+    final fun component1(): kotlin/Int // examples.classes/D.component1|component1(){}[0]
+    final fun copy(kotlin/Int =...): examples.classes/D // examples.classes/D.copy|copy(kotlin.Int){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // examples.classes/D.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // examples.classes/D.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // examples.classes/D.toString|toString(){}[0]
+}
+
+final class examples.classes/Exp { // examples.classes/Exp|null[0]
+    constructor <init>(kotlin/Int, kotlin/Int) // examples.classes/Exp.<init>|<init>(kotlin.Int;kotlin.Int){}[0]
+
+    final val vi1 // examples.classes/Exp.vi1|{}vi1[0]
+        final fun <get-vi1>(): kotlin/Int // examples.classes/Exp.vi1.<get-vi1>|<get-vi1>(){}[0]
+    final val vi2 // examples.classes/Exp.vi2|{}vi2[0]
+        final fun <get-vi2>(): kotlin/Int // examples.classes/Exp.vi2.<get-vi2>|<get-vi2>(){}[0]
+    final val vi3 // examples.classes/Exp.vi3|{}vi3[0]
+        final fun <get-vi3>(): kotlin/Int // examples.classes/Exp.vi3.<get-vi3>|<get-vi3>(){}[0]
+
+    final var v1 // examples.classes/Exp.v1|{}v1[0]
+        final fun <get-v1>(): kotlin/Int // examples.classes/Exp.v1.<get-v1>|<get-v1>(){}[0]
+        final fun <set-v1>(kotlin/Int) // examples.classes/Exp.v1.<set-v1>|<set-v1>(kotlin.Int){}[0]
+    final var v2 // examples.classes/Exp.v2|{}v2[0]
+        final fun <get-v2>(): kotlin/Int // examples.classes/Exp.v2.<get-v2>|<get-v2>(){}[0]
+        final fun <set-v2>(kotlin/Int) // examples.classes/Exp.v2.<set-v2>|<set-v2>(kotlin.Int){}[0]
+    final var v3 // examples.classes/Exp.v3|{}v3[0]
+        final fun <get-v3>(): kotlin/Int // examples.classes/Exp.v3.<get-v3>|<get-v3>(){}[0]
+        final fun <set-v3>(kotlin/Int) // examples.classes/Exp.v3.<set-v3>|<set-v3>(kotlin.Int){}[0]
+
+    final fun a(): kotlin/Int // examples.classes/Exp.a|a(){}[0]
+    final fun b(): kotlin/Int // examples.classes/Exp.b|b(){}[0]
+    final fun c(): kotlin/Int // examples.classes/Exp.c|c(){}[0]
+
+    // Targets: [linux, mingwX64]
+    final fun e(): kotlin/Int // examples.classes/Exp.e|e(){}[0]
+
+    // Targets: [linux]
+    final val vi4 // examples.classes/Exp.vi4|{}vi4[0]
+        final fun <get-vi4>(): kotlin/Int // examples.classes/Exp.vi4.<get-vi4>|<get-vi4>(){}[0]
+
+    // Targets: [linux]
+    final var v4 // examples.classes/Exp.v4|{}v4[0]
+        final fun <get-v4>(): kotlin/Int // examples.classes/Exp.v4.<get-v4>|<get-v4>(){}[0]
+        final fun <set-v4>(kotlin/Int) // examples.classes/Exp.v4.<set-v4>|<set-v4>(kotlin.Int){}[0]
+
+    // Targets: [linux]
+    final fun d(): kotlin/Int // examples.classes/Exp.d|d(){}[0]
+
+    // Targets: [mingwX64]
+    final val vi5 // examples.classes/Exp.vi5|{}vi5[0]
+        final fun <get-vi5>(): kotlin/Int // examples.classes/Exp.vi5.<get-vi5>|<get-vi5>(){}[0]
+
+    // Targets: [mingwX64]
+    final fun f(): kotlin/Int // examples.classes/Exp.f|f(){}[0]
+}
+
+final class examples.classes/IC : examples.classes/II { // examples.classes/IC|null[0]
+    constructor <init>() // examples.classes/IC.<init>|<init>(){}[0]
+}
+
+final class examples.classes/Outer { // examples.classes/Outer|null[0]
+    constructor <init>() // examples.classes/Outer.<init>|<init>(){}[0]
+
+    final class Nested { // examples.classes/Outer.Nested|null[0]
+        constructor <init>() // examples.classes/Outer.Nested.<init>|<init>(){}[0]
+
+        final enum class NE : kotlin/Enum<examples.classes/Outer.Nested.NE> { // examples.classes/Outer.Nested.NE|null[0]
+            enum entry A // examples.classes/Outer.Nested.NE.A|null[0]
+            enum entry B // examples.classes/Outer.Nested.NE.B|null[0]
+            enum entry C // examples.classes/Outer.Nested.NE.C|null[0]
+
+            final val entries // examples.classes/Outer.Nested.NE.entries|#static{}entries[0]
+                final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.entries.<get-entries>|<get-entries>#static(){}[0]
+
+            final fun valueOf(kotlin/String): examples.classes/Outer.Nested.NE // examples.classes/Outer.Nested.NE.valueOf|valueOf#static(kotlin.String){}[0]
+            final fun values(): kotlin/Array<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.values|values#static(){}[0]
+        }
+
+        final inner class Inner { // examples.classes/Outer.Nested.Inner|null[0]
+            constructor <init>() // examples.classes/Outer.Nested.Inner.<init>|<init>(){}[0]
+        }
+
+        final inner class YetAnotherInner { // examples.classes/Outer.Nested.YetAnotherInner|null[0]
+            constructor <init>() // examples.classes/Outer.Nested.YetAnotherInner.<init>|<init>(){}[0]
+        }
+    }
+}
+
+open class examples.classes/OC { // examples.classes/OC|null[0]
+    constructor <init>(kotlin/Int) // examples.classes/OC.<init>|<init>(kotlin.Int){}[0]
+    constructor <init>(kotlin/Long) // examples.classes/OC.<init>|<init>(kotlin.Long){}[0]
+    constructor <init>(kotlin/String) // examples.classes/OC.<init>|<init>(kotlin.String){}[0]
+
+    final val ix // examples.classes/OC.ix|{}ix[0]
+        final fun <get-ix>(): kotlin/Int // examples.classes/OC.ix.<get-ix>|<get-ix>(){}[0]
+    final val iy // examples.classes/OC.iy|{}iy[0]
+        final fun <get-iy>(): kotlin/Long // examples.classes/OC.iy.<get-iy>|<get-iy>(){}[0]
+    final val iz // examples.classes/OC.iz|{}iz[0]
+        final fun <get-iz>(): kotlin/String // examples.classes/OC.iz.<get-iz>|<get-iz>(){}[0]
+
+    final var x // examples.classes/OC.x|{}x[0]
+        final fun <get-x>(): kotlin/Int // examples.classes/OC.x.<get-x>|<get-x>(){}[0]
+        final fun <set-x>(kotlin/Int) // examples.classes/OC.x.<set-x>|<set-x>(kotlin.Int){}[0]
+    final var y // examples.classes/OC.y|{}y[0]
+        final fun <get-y>(): kotlin/Int // examples.classes/OC.y.<get-y>|<get-y>(){}[0]
+        final fun <set-y>(kotlin/Int) // examples.classes/OC.y.<set-y>|<set-y>(kotlin.Int){}[0]
+    final var z // examples.classes/OC.z|{}z[0]
+        final fun <get-z>(): kotlin/Int // examples.classes/OC.z.<get-z>|<get-z>(){}[0]
+        final fun <set-z>(kotlin/Int) // examples.classes/OC.z.<set-z>|<set-z>(kotlin.Int){}[0]
+
+    final fun c() // examples.classes/OC.c|c(){}[0]
+    open fun o(): kotlin/Int // examples.classes/OC.o|o(){}[0]
+}
+
+final object examples.classes/O // examples.classes/O|null[0]
+
+final object examples.classes/OO // examples.classes/OO|null[0]
+
+final const val examples.classes/con // examples.classes/con|{}con[0]
+    final fun <get-con>(): kotlin/String // examples.classes/con.<get-con>|<get-con>(){}[0]
+final const val examples.classes/intCon // examples.classes/intCon|{}intCon[0]
+    final fun <get-intCon>(): kotlin/Int // examples.classes/intCon.<get-intCon>|<get-intCon>(){}[0]
+
+final val examples.classes/a // examples.classes/a|{}a[0]
+    final fun <get-a>(): kotlin/Any // examples.classes/a.<get-a>|<get-a>(){}[0]
+final val examples.classes/i // examples.classes/i|{}i[0]
+    final fun <get-i>(): kotlin/Int // examples.classes/i.<get-i>|<get-i>(){}[0]
+final val examples.classes/l // examples.classes/l|{}l[0]
+    final fun <get-l>(): kotlin/Long // examples.classes/l.<get-l>|<get-l>(){}[0]
+
+final var examples.classes/d // examples.classes/d|{}d[0]
+    final fun <get-d>(): kotlin/Double // examples.classes/d.<get-d>|<get-d>(){}[0]
+    final fun <set-d>(kotlin/Double) // examples.classes/d.<set-d>|<set-d>(kotlin.Double){}[0]
+final var examples.classes/r // examples.classes/r|{}r[0]
+    final fun <get-r>(): kotlin/Float // examples.classes/r.<get-r>|<get-r>(){}[0]
+    final fun <set-r>(kotlin/Float) // examples.classes/r.<set-r>|<set-r>(kotlin.Float){}[0]
+
+final fun <#A: kotlin/Any?> examples.classes/consume(#A) // examples.classes/consume|consume(0:0){0§<kotlin.Any?>}[0]
+final fun examples.classes/testFun(): kotlin/Int // examples.classes/testFun|testFun(){}[0]
+final inline fun examples.classes/testInlineFun() // examples.classes/testInlineFun|testInlineFun(){}[0]
+
+// Targets: [androidNative, linux]
+final class examples.classes/AndroidAndLinuxClass { // examples.classes/AndroidAndLinuxClass|null[0]
+    constructor <init>() // examples.classes/AndroidAndLinuxClass.<init>|<init>(){}[0]
+}
+
+// Targets: [androidNative, linux]
+final val examples.classes/androidAndLinuxVal // examples.classes/androidAndLinuxVal|{}androidAndLinuxVal[0]
+    final fun <get-androidAndLinuxVal>(): kotlin/Int // examples.classes/androidAndLinuxVal.<get-androidAndLinuxVal>|<get-androidAndLinuxVal>(){}[0]
+
+// Targets: [linux]
+final class examples.classes/LinuxClass { // examples.classes/LinuxClass|null[0]
+    constructor <init>() // examples.classes/LinuxClass.<init>|<init>(){}[0]
+}
+
+// Targets: [linux]
+final val examples.classes/linuxVal // examples.classes/linuxVal|{}linuxVal[0]
+    final fun <get-linuxVal>(): kotlin/Int // examples.classes/linuxVal.<get-linuxVal>|<get-linuxVal>(){}[0]
+
+// Targets: [linux]
+final fun examples.classes/anotherLinuxFun(): kotlin/Int // examples.classes/anotherLinuxFun|anotherLinuxFun(){}[0]
+
+// Targets: [linux]
+final fun examples.classes/linuxFun(): kotlin/String // examples.classes/linuxFun|linuxFun(){}[0]

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.dump
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.dump
@@ -9,90 +9,120 @@
 open annotation class examples.classes/A : kotlin/Annotation { // examples.classes/A|null[0]
     constructor <init>() // examples.classes/A.<init>|<init>(){}[0]
 }
+
 open annotation class examples.classes/AA : kotlin/Annotation { // examples.classes/AA|null[0]
     constructor <init>() // examples.classes/AA.<init>|<init>(){}[0]
 }
+
 open annotation class examples.classes/AAA : kotlin/Annotation { // examples.classes/AAA|null[0]
     constructor <init>() // examples.classes/AAA.<init>|<init>(){}[0]
 }
+
 final enum class examples.classes/E : kotlin/Enum<examples.classes/E> { // examples.classes/E|null[0]
     enum entry A // examples.classes/E.A|null[0]
     enum entry B // examples.classes/E.B|null[0]
     enum entry C // examples.classes/E.C|null[0]
+
     final val entries // examples.classes/E.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/E> // examples.classes/E.entries.<get-entries>|<get-entries>#static(){}[0]
+
     final fun valueOf(kotlin/String): examples.classes/E // examples.classes/E.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<examples.classes/E> // examples.classes/E.values|values#static(){}[0]
 }
+
 final enum class examples.classes/EE : kotlin/Enum<examples.classes/EE> { // examples.classes/EE|null[0]
     enum entry AA // examples.classes/EE.AA|null[0]
     enum entry BB // examples.classes/EE.BB|null[0]
     enum entry CC // examples.classes/EE.CC|null[0]
+
     final val entries // examples.classes/EE.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/EE> // examples.classes/EE.entries.<get-entries>|<get-entries>#static(){}[0]
+
     final fun valueOf(kotlin/String): examples.classes/EE // examples.classes/EE.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<examples.classes/EE> // examples.classes/EE.values|values#static(){}[0]
 }
+
 abstract fun interface examples.classes/FI { // examples.classes/FI|null[0]
     abstract fun a() // examples.classes/FI.a|a(){}[0]
 }
+
 abstract interface examples.classes/I // examples.classes/I|null[0]
+
 abstract interface examples.classes/II // examples.classes/II|null[0]
+
 abstract class examples.classes/AC { // examples.classes/AC|null[0]
     constructor <init>() // examples.classes/AC.<init>|<init>(){}[0]
+
     abstract fun a() // examples.classes/AC.a|a(){}[0]
     final fun b() // examples.classes/AC.b|b(){}[0]
 }
+
 final class examples.classes/C { // examples.classes/C|null[0]
     constructor <init>(kotlin/Any) // examples.classes/C.<init>|<init>(kotlin.Any){}[0]
+
     final val v // examples.classes/C.v|{}v[0]
         final fun <get-v>(): kotlin/Any // examples.classes/C.v.<get-v>|<get-v>(){}[0]
+
     final fun m() // examples.classes/C.m|m(){}[0]
 }
+
 final class examples.classes/D { // examples.classes/D|null[0]
     constructor <init>(kotlin/Int) // examples.classes/D.<init>|<init>(kotlin.Int){}[0]
+
     final val x // examples.classes/D.x|{}x[0]
         final fun <get-x>(): kotlin/Int // examples.classes/D.x.<get-x>|<get-x>(){}[0]
+
     final fun component1(): kotlin/Int // examples.classes/D.component1|component1(){}[0]
     final fun copy(kotlin/Int =...): examples.classes/D // examples.classes/D.copy|copy(kotlin.Int){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // examples.classes/D.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // examples.classes/D.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // examples.classes/D.toString|toString(){}[0]
 }
+
 final class examples.classes/IC : examples.classes/II { // examples.classes/IC|null[0]
     constructor <init>() // examples.classes/IC.<init>|<init>(){}[0]
 }
+
 final class examples.classes/Outer { // examples.classes/Outer|null[0]
     constructor <init>() // examples.classes/Outer.<init>|<init>(){}[0]
+
     final class Nested { // examples.classes/Outer.Nested|null[0]
         constructor <init>() // examples.classes/Outer.Nested.<init>|<init>(){}[0]
+
         final enum class NE : kotlin/Enum<examples.classes/Outer.Nested.NE> { // examples.classes/Outer.Nested.NE|null[0]
             enum entry A // examples.classes/Outer.Nested.NE.A|null[0]
             enum entry B // examples.classes/Outer.Nested.NE.B|null[0]
             enum entry C // examples.classes/Outer.Nested.NE.C|null[0]
+
             final val entries // examples.classes/Outer.Nested.NE.entries|#static{}entries[0]
                 final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.entries.<get-entries>|<get-entries>#static(){}[0]
+
             final fun valueOf(kotlin/String): examples.classes/Outer.Nested.NE // examples.classes/Outer.Nested.NE.valueOf|valueOf#static(kotlin.String){}[0]
             final fun values(): kotlin/Array<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.values|values#static(){}[0]
         }
+
         final inner class Inner { // examples.classes/Outer.Nested.Inner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.Inner.<init>|<init>(){}[0]
         }
+
         final inner class YetAnotherInner { // examples.classes/Outer.Nested.YetAnotherInner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.YetAnotherInner.<init>|<init>(){}[0]
         }
     }
 }
+
 open class examples.classes/OC { // examples.classes/OC|null[0]
     constructor <init>(kotlin/Int) // examples.classes/OC.<init>|<init>(kotlin.Int){}[0]
     constructor <init>(kotlin/Long) // examples.classes/OC.<init>|<init>(kotlin.Long){}[0]
     constructor <init>(kotlin/String) // examples.classes/OC.<init>|<init>(kotlin.String){}[0]
+
     final val ix // examples.classes/OC.ix|{}ix[0]
         final fun <get-ix>(): kotlin/Int // examples.classes/OC.ix.<get-ix>|<get-ix>(){}[0]
     final val iy // examples.classes/OC.iy|{}iy[0]
         final fun <get-iy>(): kotlin/Long // examples.classes/OC.iy.<get-iy>|<get-iy>(){}[0]
     final val iz // examples.classes/OC.iz|{}iz[0]
         final fun <get-iz>(): kotlin/String // examples.classes/OC.iz.<get-iz>|<get-iz>(){}[0]
+
     final var x // examples.classes/OC.x|{}x[0]
         final fun <get-x>(): kotlin/Int // examples.classes/OC.x.<get-x>|<get-x>(){}[0]
         final fun <set-x>(kotlin/Int) // examples.classes/OC.x.<set-x>|<set-x>(kotlin.Int){}[0]
@@ -102,27 +132,34 @@ open class examples.classes/OC { // examples.classes/OC|null[0]
     final var z // examples.classes/OC.z|{}z[0]
         final fun <get-z>(): kotlin/Int // examples.classes/OC.z.<get-z>|<get-z>(){}[0]
         final fun <set-z>(kotlin/Int) // examples.classes/OC.z.<set-z>|<set-z>(kotlin.Int){}[0]
+
     final fun c() // examples.classes/OC.c|c(){}[0]
     open fun o(): kotlin/Int // examples.classes/OC.o|o(){}[0]
 }
+
 final object examples.classes/O // examples.classes/O|null[0]
+
 final object examples.classes/OO // examples.classes/OO|null[0]
+
 final const val examples.classes/con // examples.classes/con|{}con[0]
     final fun <get-con>(): kotlin/String // examples.classes/con.<get-con>|<get-con>(){}[0]
 final const val examples.classes/intCon // examples.classes/intCon|{}intCon[0]
     final fun <get-intCon>(): kotlin/Int // examples.classes/intCon.<get-intCon>|<get-intCon>(){}[0]
+
 final val examples.classes/a // examples.classes/a|{}a[0]
     final fun <get-a>(): kotlin/Any // examples.classes/a.<get-a>|<get-a>(){}[0]
 final val examples.classes/i // examples.classes/i|{}i[0]
     final fun <get-i>(): kotlin/Int // examples.classes/i.<get-i>|<get-i>(){}[0]
 final val examples.classes/l // examples.classes/l|{}l[0]
     final fun <get-l>(): kotlin/Long // examples.classes/l.<get-l>|<get-l>(){}[0]
+
 final var examples.classes/d // examples.classes/d|{}d[0]
     final fun <get-d>(): kotlin/Double // examples.classes/d.<get-d>|<get-d>(){}[0]
     final fun <set-d>(kotlin/Double) // examples.classes/d.<set-d>|<set-d>(kotlin.Double){}[0]
 final var examples.classes/r // examples.classes/r|{}r[0]
     final fun <get-r>(): kotlin/Float // examples.classes/r.<get-r>|<get-r>(){}[0]
     final fun <set-r>(kotlin/Float) // examples.classes/r.<set-r>|<set-r>(kotlin.Float){}[0]
+
 final fun <#A: kotlin/Any?> examples.classes/consume(#A) // examples.classes/consume|consume(0:0){0§<kotlin.Any?>}[0]
 final fun examples.classes/testFun(): kotlin/Int // examples.classes/testFun|testFun(){}[0]
 final inline fun examples.classes/testInlineFun() // examples.classes/testInlineFun|testInlineFun(){}[0]

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.unsup.dump
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.unsup.dump
@@ -9,90 +9,120 @@
 open annotation class examples.classes/A : kotlin/Annotation { // examples.classes/A|null[0]
     constructor <init>() // examples.classes/A.<init>|<init>(){}[0]
 }
+
 open annotation class examples.classes/AA : kotlin/Annotation { // examples.classes/AA|null[0]
     constructor <init>() // examples.classes/AA.<init>|<init>(){}[0]
 }
+
 open annotation class examples.classes/AAA : kotlin/Annotation { // examples.classes/AAA|null[0]
     constructor <init>() // examples.classes/AAA.<init>|<init>(){}[0]
 }
+
 final enum class examples.classes/E : kotlin/Enum<examples.classes/E> { // examples.classes/E|null[0]
     enum entry A // examples.classes/E.A|null[0]
     enum entry B // examples.classes/E.B|null[0]
     enum entry C // examples.classes/E.C|null[0]
+
     final val entries // examples.classes/E.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/E> // examples.classes/E.entries.<get-entries>|<get-entries>#static(){}[0]
+
     final fun valueOf(kotlin/String): examples.classes/E // examples.classes/E.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<examples.classes/E> // examples.classes/E.values|values#static(){}[0]
 }
+
 final enum class examples.classes/EE : kotlin/Enum<examples.classes/EE> { // examples.classes/EE|null[0]
     enum entry AA // examples.classes/EE.AA|null[0]
     enum entry BB // examples.classes/EE.BB|null[0]
     enum entry CC // examples.classes/EE.CC|null[0]
+
     final val entries // examples.classes/EE.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/EE> // examples.classes/EE.entries.<get-entries>|<get-entries>#static(){}[0]
+
     final fun valueOf(kotlin/String): examples.classes/EE // examples.classes/EE.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<examples.classes/EE> // examples.classes/EE.values|values#static(){}[0]
 }
+
 abstract fun interface examples.classes/FI { // examples.classes/FI|null[0]
     abstract fun a() // examples.classes/FI.a|a(){}[0]
 }
+
 abstract interface examples.classes/I // examples.classes/I|null[0]
+
 abstract interface examples.classes/II // examples.classes/II|null[0]
+
 abstract class examples.classes/AC { // examples.classes/AC|null[0]
     constructor <init>() // examples.classes/AC.<init>|<init>(){}[0]
+
     abstract fun a() // examples.classes/AC.a|a(){}[0]
     final fun b() // examples.classes/AC.b|b(){}[0]
 }
+
 final class examples.classes/C { // examples.classes/C|null[0]
     constructor <init>(kotlin/Any) // examples.classes/C.<init>|<init>(kotlin.Any){}[0]
+
     final val v // examples.classes/C.v|{}v[0]
         final fun <get-v>(): kotlin/Any // examples.classes/C.v.<get-v>|<get-v>(){}[0]
+
     final fun m() // examples.classes/C.m|m(){}[0]
 }
+
 final class examples.classes/D { // examples.classes/D|null[0]
     constructor <init>(kotlin/Int) // examples.classes/D.<init>|<init>(kotlin.Int){}[0]
+
     final val x // examples.classes/D.x|{}x[0]
         final fun <get-x>(): kotlin/Int // examples.classes/D.x.<get-x>|<get-x>(){}[0]
+
     final fun component1(): kotlin/Int // examples.classes/D.component1|component1(){}[0]
     final fun copy(kotlin/Int =...): examples.classes/D // examples.classes/D.copy|copy(kotlin.Int){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // examples.classes/D.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // examples.classes/D.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // examples.classes/D.toString|toString(){}[0]
 }
+
 final class examples.classes/IC : examples.classes/II { // examples.classes/IC|null[0]
     constructor <init>() // examples.classes/IC.<init>|<init>(){}[0]
 }
+
 final class examples.classes/Outer { // examples.classes/Outer|null[0]
     constructor <init>() // examples.classes/Outer.<init>|<init>(){}[0]
+
     final class Nested { // examples.classes/Outer.Nested|null[0]
         constructor <init>() // examples.classes/Outer.Nested.<init>|<init>(){}[0]
+
         final enum class NE : kotlin/Enum<examples.classes/Outer.Nested.NE> { // examples.classes/Outer.Nested.NE|null[0]
             enum entry A // examples.classes/Outer.Nested.NE.A|null[0]
             enum entry B // examples.classes/Outer.Nested.NE.B|null[0]
             enum entry C // examples.classes/Outer.Nested.NE.C|null[0]
+
             final val entries // examples.classes/Outer.Nested.NE.entries|#static{}entries[0]
                 final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.entries.<get-entries>|<get-entries>#static(){}[0]
+
             final fun valueOf(kotlin/String): examples.classes/Outer.Nested.NE // examples.classes/Outer.Nested.NE.valueOf|valueOf#static(kotlin.String){}[0]
             final fun values(): kotlin/Array<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.values|values#static(){}[0]
         }
+
         final inner class Inner { // examples.classes/Outer.Nested.Inner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.Inner.<init>|<init>(){}[0]
         }
+
         final inner class YetAnotherInner { // examples.classes/Outer.Nested.YetAnotherInner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.YetAnotherInner.<init>|<init>(){}[0]
         }
     }
 }
+
 open class examples.classes/OC { // examples.classes/OC|null[0]
     constructor <init>(kotlin/Int) // examples.classes/OC.<init>|<init>(kotlin.Int){}[0]
     constructor <init>(kotlin/Long) // examples.classes/OC.<init>|<init>(kotlin.Long){}[0]
     constructor <init>(kotlin/String) // examples.classes/OC.<init>|<init>(kotlin.String){}[0]
+
     final val ix // examples.classes/OC.ix|{}ix[0]
         final fun <get-ix>(): kotlin/Int // examples.classes/OC.ix.<get-ix>|<get-ix>(){}[0]
     final val iy // examples.classes/OC.iy|{}iy[0]
         final fun <get-iy>(): kotlin/Long // examples.classes/OC.iy.<get-iy>|<get-iy>(){}[0]
     final val iz // examples.classes/OC.iz|{}iz[0]
         final fun <get-iz>(): kotlin/String // examples.classes/OC.iz.<get-iz>|<get-iz>(){}[0]
+
     final var x // examples.classes/OC.x|{}x[0]
         final fun <get-x>(): kotlin/Int // examples.classes/OC.x.<get-x>|<get-x>(){}[0]
         final fun <set-x>(kotlin/Int) // examples.classes/OC.x.<set-x>|<set-x>(kotlin.Int){}[0]
@@ -102,27 +132,34 @@ open class examples.classes/OC { // examples.classes/OC|null[0]
     final var z // examples.classes/OC.z|{}z[0]
         final fun <get-z>(): kotlin/Int // examples.classes/OC.z.<get-z>|<get-z>(){}[0]
         final fun <set-z>(kotlin/Int) // examples.classes/OC.z.<set-z>|<set-z>(kotlin.Int){}[0]
+
     final fun c() // examples.classes/OC.c|c(){}[0]
     open fun o(): kotlin/Int // examples.classes/OC.o|o(){}[0]
 }
+
 final object examples.classes/O // examples.classes/O|null[0]
+
 final object examples.classes/OO // examples.classes/OO|null[0]
+
 final const val examples.classes/con // examples.classes/con|{}con[0]
     final fun <get-con>(): kotlin/String // examples.classes/con.<get-con>|<get-con>(){}[0]
 final const val examples.classes/intCon // examples.classes/intCon|{}intCon[0]
     final fun <get-intCon>(): kotlin/Int // examples.classes/intCon.<get-intCon>|<get-intCon>(){}[0]
+
 final val examples.classes/a // examples.classes/a|{}a[0]
     final fun <get-a>(): kotlin/Any // examples.classes/a.<get-a>|<get-a>(){}[0]
 final val examples.classes/i // examples.classes/i|{}i[0]
     final fun <get-i>(): kotlin/Int // examples.classes/i.<get-i>|<get-i>(){}[0]
 final val examples.classes/l // examples.classes/l|{}l[0]
     final fun <get-l>(): kotlin/Long // examples.classes/l.<get-l>|<get-l>(){}[0]
+
 final var examples.classes/d // examples.classes/d|{}d[0]
     final fun <get-d>(): kotlin/Double // examples.classes/d.<get-d>|<get-d>(){}[0]
     final fun <set-d>(kotlin/Double) // examples.classes/d.<set-d>|<set-d>(kotlin.Double){}[0]
 final var examples.classes/r // examples.classes/r|{}r[0]
     final fun <get-r>(): kotlin/Float // examples.classes/r.<get-r>|<get-r>(){}[0]
     final fun <set-r>(kotlin/Float) // examples.classes/r.<set-r>|<set-r>(kotlin.Float){}[0]
+
 final fun <#A: kotlin/Any?> examples.classes/consume(#A) // examples.classes/consume|consume(0:0){0§<kotlin.Any?>}[0]
 final fun examples.classes/testFun(): kotlin/Int // examples.classes/testFun|testFun(){}[0]
 final inline fun examples.classes/testInlineFun() // examples.classes/testInlineFun|testInlineFun(){}[0]

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.v1.dump
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.v1.dump
@@ -9,90 +9,120 @@
 open annotation class examples.classes/A : kotlin/Annotation { // examples.classes/A|null[0]
     constructor <init>() // examples.classes/A.<init>|-5645683436151566731[0]
 }
+
 open annotation class examples.classes/AA : kotlin/Annotation { // examples.classes/AA|null[0]
     constructor <init>() // examples.classes/AA.<init>|-5645683436151566731[0]
 }
+
 open annotation class examples.classes/AAA : kotlin/Annotation { // examples.classes/AAA|null[0]
     constructor <init>() // examples.classes/AAA.<init>|-5645683436151566731[0]
 }
+
 final enum class examples.classes/E : kotlin/Enum<examples.classes/E> { // examples.classes/E|null[0]
     enum entry A // examples.classes/E.A|null[0]
     enum entry B // examples.classes/E.B|null[0]
     enum entry C // examples.classes/E.C|null[0]
+
     final val entries // examples.classes/E.entries|-5134227801081826149[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/E> // examples.classes/E.entries.<get-entries>|-6068527377476727729[0]
+
     final fun valueOf(kotlin/String): examples.classes/E // examples.classes/E.valueOf|-4683474617854611729[0]
     final fun values(): kotlin/Array<examples.classes/E> // examples.classes/E.values|-8715569000920726747[0]
 }
+
 final enum class examples.classes/EE : kotlin/Enum<examples.classes/EE> { // examples.classes/EE|null[0]
     enum entry AA // examples.classes/EE.AA|null[0]
     enum entry BB // examples.classes/EE.BB|null[0]
     enum entry CC // examples.classes/EE.CC|null[0]
+
     final val entries // examples.classes/EE.entries|-5134227801081826149[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/EE> // examples.classes/EE.entries.<get-entries>|-6068527377476727729[0]
+
     final fun valueOf(kotlin/String): examples.classes/EE // examples.classes/EE.valueOf|-4683474617854611729[0]
     final fun values(): kotlin/Array<examples.classes/EE> // examples.classes/EE.values|-8715569000920726747[0]
 }
+
 abstract fun interface examples.classes/FI { // examples.classes/FI|null[0]
     abstract fun a() // examples.classes/FI.a|-4432112437378250461[0]
 }
+
 abstract interface examples.classes/I // examples.classes/I|null[0]
+
 abstract interface examples.classes/II // examples.classes/II|null[0]
+
 abstract class examples.classes/AC { // examples.classes/AC|null[0]
     constructor <init>() // examples.classes/AC.<init>|-5645683436151566731[0]
+
     abstract fun a() // examples.classes/AC.a|-4432112437378250461[0]
     final fun b() // examples.classes/AC.b|4789657038926421504[0]
 }
+
 final class examples.classes/C { // examples.classes/C|null[0]
     constructor <init>(kotlin/Any) // examples.classes/C.<init>|4518179880532599055[0]
+
     final val v // examples.classes/C.v|138869847852828796[0]
         final fun <get-v>(): kotlin/Any // examples.classes/C.v.<get-v>|4964732996156868941[0]
+
     final fun m() // examples.classes/C.m|-1029306787563722981[0]
 }
+
 final class examples.classes/D { // examples.classes/D|null[0]
     constructor <init>(kotlin/Int) // examples.classes/D.<init>|-5182794243525578284[0]
+
     final val x // examples.classes/D.x|-8060530855978347579[0]
         final fun <get-x>(): kotlin/Int // examples.classes/D.x.<get-x>|1482705010654679335[0]
+
     final fun component1(): kotlin/Int // examples.classes/D.component1|162597135895221648[0]
     final fun copy(kotlin/Int =...): examples.classes/D // examples.classes/D.copy|-6971662324481626298[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // examples.classes/D.equals|4638265728071529943[0]
     final fun hashCode(): kotlin/Int // examples.classes/D.hashCode|3409210261493131192[0]
     final fun toString(): kotlin/String // examples.classes/D.toString|-1522858123163872138[0]
 }
+
 final class examples.classes/IC : examples.classes/II { // examples.classes/IC|null[0]
     constructor <init>() // examples.classes/IC.<init>|-5645683436151566731[0]
 }
+
 final class examples.classes/Outer { // examples.classes/Outer|null[0]
     constructor <init>() // examples.classes/Outer.<init>|-5645683436151566731[0]
+
     final class Nested { // examples.classes/Outer.Nested|null[0]
         constructor <init>() // examples.classes/Outer.Nested.<init>|-5645683436151566731[0]
+
         final enum class NE : kotlin/Enum<examples.classes/Outer.Nested.NE> { // examples.classes/Outer.Nested.NE|null[0]
             enum entry A // examples.classes/Outer.Nested.NE.A|null[0]
             enum entry B // examples.classes/Outer.Nested.NE.B|null[0]
             enum entry C // examples.classes/Outer.Nested.NE.C|null[0]
+
             final val entries // examples.classes/Outer.Nested.NE.entries|-5134227801081826149[0]
                 final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.entries.<get-entries>|-6068527377476727729[0]
+
             final fun valueOf(kotlin/String): examples.classes/Outer.Nested.NE // examples.classes/Outer.Nested.NE.valueOf|-4683474617854611729[0]
             final fun values(): kotlin/Array<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.values|-8715569000920726747[0]
         }
+
         final inner class Inner { // examples.classes/Outer.Nested.Inner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.Inner.<init>|-5645683436151566731[0]
         }
+
         final inner class YetAnotherInner { // examples.classes/Outer.Nested.YetAnotherInner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.YetAnotherInner.<init>|-5645683436151566731[0]
         }
     }
 }
+
 open class examples.classes/OC { // examples.classes/OC|null[0]
     constructor <init>(kotlin/Int) // examples.classes/OC.<init>|-5182794243525578284[0]
     constructor <init>(kotlin/Long) // examples.classes/OC.<init>|5217973964116651322[0]
     constructor <init>(kotlin/String) // examples.classes/OC.<init>|1280618353163213788[0]
+
     final val ix // examples.classes/OC.ix|5586787718776183610[0]
         final fun <get-ix>(): kotlin/Int // examples.classes/OC.ix.<get-ix>|6412451035637198934[0]
     final val iy // examples.classes/OC.iy|-4863546984470764583[0]
         final fun <get-iy>(): kotlin/Long // examples.classes/OC.iy.<get-iy>|-4932930205028660775[0]
     final val iz // examples.classes/OC.iz|-6916102702480625188[0]
         final fun <get-iz>(): kotlin/String // examples.classes/OC.iz.<get-iz>|8935463596906645831[0]
+
     final var x // examples.classes/OC.x|-8060530855978347579[0]
         final fun <get-x>(): kotlin/Int // examples.classes/OC.x.<get-x>|1482705010654679335[0]
         final fun <set-x>(kotlin/Int) // examples.classes/OC.x.<set-x>|-740209739415615559[0]
@@ -102,27 +132,34 @@ open class examples.classes/OC { // examples.classes/OC|null[0]
     final var z // examples.classes/OC.z|7549650372729116193[0]
         final fun <get-z>(): kotlin/Int // examples.classes/OC.z.<get-z>|4925813204745917177[0]
         final fun <set-z>(kotlin/Int) // examples.classes/OC.z.<set-z>|8486465404430625584[0]
+
     final fun c() // examples.classes/OC.c|-2724918380551733646[0]
     open fun o(): kotlin/Int // examples.classes/OC.o|-3264635847192431671[0]
 }
+
 final object examples.classes/O // examples.classes/O|null[0]
+
 final object examples.classes/OO // examples.classes/OO|null[0]
+
 final const val examples.classes/con // examples.classes/con|-2899158152154217071[0]
     final fun <get-con>(): kotlin/String // examples.classes/con.<get-con>|-2604863570302238407[0]
 final const val examples.classes/intCon // examples.classes/intCon|-4533540985615038728[0]
     final fun <get-intCon>(): kotlin/Int // examples.classes/intCon.<get-intCon>|-7661624206875263703[0]
+
 final val examples.classes/a // examples.classes/a|-1200697420457237799[0]
     final fun <get-a>(): kotlin/Any // examples.classes/a.<get-a>|6785176174175479410[0]
 final val examples.classes/i // examples.classes/i|5014384761142332495[0]
     final fun <get-i>(): kotlin/Int // examples.classes/i.<get-i>|6945482638966853621[0]
 final val examples.classes/l // examples.classes/l|3307215303229595169[0]
     final fun <get-l>(): kotlin/Long // examples.classes/l.<get-l>|3795442967620585[0]
+
 final var examples.classes/d // examples.classes/d|5174763769109925331[0]
     final fun <get-d>(): kotlin/Double // examples.classes/d.<get-d>|-6701718004621354461[0]
     final fun <set-d>(kotlin/Double) // examples.classes/d.<set-d>|-6916287485929380915[0]
 final var examples.classes/r // examples.classes/r|-8117627916896159533[0]
     final fun <get-r>(): kotlin/Float // examples.classes/r.<get-r>|-7424184448774736572[0]
     final fun <set-r>(kotlin/Float) // examples.classes/r.<set-r>|9171637170963327464[0]
+
 final fun <#A: kotlin/Any?> examples.classes/consume(#A) // examples.classes/consume|8042761629495509481[0]
 final fun examples.classes/testFun(): kotlin/Int // examples.classes/testFun|6322333980269160703[0]
 final inline fun examples.classes/testInlineFun() // examples.classes/testInlineFun|-9193388292326484960[0]

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.with.guessed.linux.dump
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.with.guessed.linux.dump
@@ -9,90 +9,120 @@
 open annotation class examples.classes/A : kotlin/Annotation { // examples.classes/A|null[0]
     constructor <init>() // examples.classes/A.<init>|<init>(){}[0]
 }
+
 open annotation class examples.classes/AA : kotlin/Annotation { // examples.classes/AA|null[0]
     constructor <init>() // examples.classes/AA.<init>|<init>(){}[0]
 }
+
 open annotation class examples.classes/AAA : kotlin/Annotation { // examples.classes/AAA|null[0]
     constructor <init>() // examples.classes/AAA.<init>|<init>(){}[0]
 }
+
 final enum class examples.classes/E : kotlin/Enum<examples.classes/E> { // examples.classes/E|null[0]
     enum entry A // examples.classes/E.A|null[0]
     enum entry B // examples.classes/E.B|null[0]
     enum entry C // examples.classes/E.C|null[0]
+
     final val entries // examples.classes/E.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/E> // examples.classes/E.entries.<get-entries>|<get-entries>#static(){}[0]
+
     final fun valueOf(kotlin/String): examples.classes/E // examples.classes/E.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<examples.classes/E> // examples.classes/E.values|values#static(){}[0]
 }
+
 final enum class examples.classes/EE : kotlin/Enum<examples.classes/EE> { // examples.classes/EE|null[0]
     enum entry AA // examples.classes/EE.AA|null[0]
     enum entry BB // examples.classes/EE.BB|null[0]
     enum entry CC // examples.classes/EE.CC|null[0]
+
     final val entries // examples.classes/EE.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/EE> // examples.classes/EE.entries.<get-entries>|<get-entries>#static(){}[0]
+
     final fun valueOf(kotlin/String): examples.classes/EE // examples.classes/EE.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<examples.classes/EE> // examples.classes/EE.values|values#static(){}[0]
 }
+
 abstract fun interface examples.classes/FI { // examples.classes/FI|null[0]
     abstract fun a() // examples.classes/FI.a|a(){}[0]
 }
+
 abstract interface examples.classes/I // examples.classes/I|null[0]
+
 abstract interface examples.classes/II // examples.classes/II|null[0]
+
 abstract class examples.classes/AC { // examples.classes/AC|null[0]
     constructor <init>() // examples.classes/AC.<init>|<init>(){}[0]
+
     abstract fun a() // examples.classes/AC.a|a(){}[0]
     final fun b() // examples.classes/AC.b|b(){}[0]
 }
+
 final class examples.classes/C { // examples.classes/C|null[0]
     constructor <init>(kotlin/Any) // examples.classes/C.<init>|<init>(kotlin.Any){}[0]
+
     final val v // examples.classes/C.v|{}v[0]
         final fun <get-v>(): kotlin/Any // examples.classes/C.v.<get-v>|<get-v>(){}[0]
+
     final fun m() // examples.classes/C.m|m(){}[0]
 }
+
 final class examples.classes/D { // examples.classes/D|null[0]
     constructor <init>(kotlin/Int) // examples.classes/D.<init>|<init>(kotlin.Int){}[0]
+
     final val x // examples.classes/D.x|{}x[0]
         final fun <get-x>(): kotlin/Int // examples.classes/D.x.<get-x>|<get-x>(){}[0]
+
     final fun component1(): kotlin/Int // examples.classes/D.component1|component1(){}[0]
     final fun copy(kotlin/Int =...): examples.classes/D // examples.classes/D.copy|copy(kotlin.Int){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // examples.classes/D.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // examples.classes/D.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // examples.classes/D.toString|toString(){}[0]
 }
+
 final class examples.classes/IC : examples.classes/II { // examples.classes/IC|null[0]
     constructor <init>() // examples.classes/IC.<init>|<init>(){}[0]
 }
+
 final class examples.classes/Outer { // examples.classes/Outer|null[0]
     constructor <init>() // examples.classes/Outer.<init>|<init>(){}[0]
+
     final class Nested { // examples.classes/Outer.Nested|null[0]
         constructor <init>() // examples.classes/Outer.Nested.<init>|<init>(){}[0]
+
         final enum class NE : kotlin/Enum<examples.classes/Outer.Nested.NE> { // examples.classes/Outer.Nested.NE|null[0]
             enum entry A // examples.classes/Outer.Nested.NE.A|null[0]
             enum entry B // examples.classes/Outer.Nested.NE.B|null[0]
             enum entry C // examples.classes/Outer.Nested.NE.C|null[0]
+
             final val entries // examples.classes/Outer.Nested.NE.entries|#static{}entries[0]
                 final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.entries.<get-entries>|<get-entries>#static(){}[0]
+
             final fun valueOf(kotlin/String): examples.classes/Outer.Nested.NE // examples.classes/Outer.Nested.NE.valueOf|valueOf#static(kotlin.String){}[0]
             final fun values(): kotlin/Array<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.values|values#static(){}[0]
         }
+
         final inner class Inner { // examples.classes/Outer.Nested.Inner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.Inner.<init>|<init>(){}[0]
         }
+
         final inner class YetAnotherInner { // examples.classes/Outer.Nested.YetAnotherInner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.YetAnotherInner.<init>|<init>(){}[0]
         }
     }
 }
+
 open class examples.classes/OC { // examples.classes/OC|null[0]
     constructor <init>(kotlin/Int) // examples.classes/OC.<init>|<init>(kotlin.Int){}[0]
     constructor <init>(kotlin/Long) // examples.classes/OC.<init>|<init>(kotlin.Long){}[0]
     constructor <init>(kotlin/String) // examples.classes/OC.<init>|<init>(kotlin.String){}[0]
+
     final val ix // examples.classes/OC.ix|{}ix[0]
         final fun <get-ix>(): kotlin/Int // examples.classes/OC.ix.<get-ix>|<get-ix>(){}[0]
     final val iy // examples.classes/OC.iy|{}iy[0]
         final fun <get-iy>(): kotlin/Long // examples.classes/OC.iy.<get-iy>|<get-iy>(){}[0]
     final val iz // examples.classes/OC.iz|{}iz[0]
         final fun <get-iz>(): kotlin/String // examples.classes/OC.iz.<get-iz>|<get-iz>(){}[0]
+
     final var x // examples.classes/OC.x|{}x[0]
         final fun <get-x>(): kotlin/Int // examples.classes/OC.x.<get-x>|<get-x>(){}[0]
         final fun <set-x>(kotlin/Int) // examples.classes/OC.x.<set-x>|<set-x>(kotlin.Int){}[0]
@@ -102,27 +132,34 @@ open class examples.classes/OC { // examples.classes/OC|null[0]
     final var z // examples.classes/OC.z|{}z[0]
         final fun <get-z>(): kotlin/Int // examples.classes/OC.z.<get-z>|<get-z>(){}[0]
         final fun <set-z>(kotlin/Int) // examples.classes/OC.z.<set-z>|<set-z>(kotlin.Int){}[0]
+
     final fun c() // examples.classes/OC.c|c(){}[0]
     open fun o(): kotlin/Int // examples.classes/OC.o|o(){}[0]
 }
+
 final object examples.classes/O // examples.classes/O|null[0]
+
 final object examples.classes/OO // examples.classes/OO|null[0]
+
 final const val examples.classes/con // examples.classes/con|{}con[0]
     final fun <get-con>(): kotlin/String // examples.classes/con.<get-con>|<get-con>(){}[0]
 final const val examples.classes/intCon // examples.classes/intCon|{}intCon[0]
     final fun <get-intCon>(): kotlin/Int // examples.classes/intCon.<get-intCon>|<get-intCon>(){}[0]
+
 final val examples.classes/a // examples.classes/a|{}a[0]
     final fun <get-a>(): kotlin/Any // examples.classes/a.<get-a>|<get-a>(){}[0]
 final val examples.classes/i // examples.classes/i|{}i[0]
     final fun <get-i>(): kotlin/Int // examples.classes/i.<get-i>|<get-i>(){}[0]
 final val examples.classes/l // examples.classes/l|{}l[0]
     final fun <get-l>(): kotlin/Long // examples.classes/l.<get-l>|<get-l>(){}[0]
+
 final var examples.classes/d // examples.classes/d|{}d[0]
     final fun <get-d>(): kotlin/Double // examples.classes/d.<get-d>|<get-d>(){}[0]
     final fun <set-d>(kotlin/Double) // examples.classes/d.<set-d>|<set-d>(kotlin.Double){}[0]
 final var examples.classes/r // examples.classes/r|{}r[0]
     final fun <get-r>(): kotlin/Float // examples.classes/r.<get-r>|<get-r>(){}[0]
     final fun <set-r>(kotlin/Float) // examples.classes/r.<set-r>|<set-r>(kotlin.Float){}[0]
+
 final fun <#A: kotlin/Any?> examples.classes/consume(#A) // examples.classes/consume|consume(0:0){0§<kotlin.Any?>}[0]
 final fun examples.classes/testFun(): kotlin/Int // examples.classes/testFun|testFun(){}[0]
 final inline fun examples.classes/testInlineFun() // examples.classes/testInlineFun|testInlineFun(){}[0]

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.with.linux.dump
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.klib.with.linux.dump
@@ -9,90 +9,120 @@
 open annotation class examples.classes/A : kotlin/Annotation { // examples.classes/A|null[0]
     constructor <init>() // examples.classes/A.<init>|<init>(){}[0]
 }
+
 open annotation class examples.classes/AA : kotlin/Annotation { // examples.classes/AA|null[0]
     constructor <init>() // examples.classes/AA.<init>|<init>(){}[0]
 }
+
 open annotation class examples.classes/AAA : kotlin/Annotation { // examples.classes/AAA|null[0]
     constructor <init>() // examples.classes/AAA.<init>|<init>(){}[0]
 }
+
 final enum class examples.classes/E : kotlin/Enum<examples.classes/E> { // examples.classes/E|null[0]
     enum entry A // examples.classes/E.A|null[0]
     enum entry B // examples.classes/E.B|null[0]
     enum entry C // examples.classes/E.C|null[0]
+
     final val entries // examples.classes/E.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/E> // examples.classes/E.entries.<get-entries>|<get-entries>#static(){}[0]
+
     final fun valueOf(kotlin/String): examples.classes/E // examples.classes/E.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<examples.classes/E> // examples.classes/E.values|values#static(){}[0]
 }
+
 final enum class examples.classes/EE : kotlin/Enum<examples.classes/EE> { // examples.classes/EE|null[0]
     enum entry AA // examples.classes/EE.AA|null[0]
     enum entry BB // examples.classes/EE.BB|null[0]
     enum entry CC // examples.classes/EE.CC|null[0]
+
     final val entries // examples.classes/EE.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/EE> // examples.classes/EE.entries.<get-entries>|<get-entries>#static(){}[0]
+
     final fun valueOf(kotlin/String): examples.classes/EE // examples.classes/EE.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<examples.classes/EE> // examples.classes/EE.values|values#static(){}[0]
 }
+
 abstract fun interface examples.classes/FI { // examples.classes/FI|null[0]
     abstract fun a() // examples.classes/FI.a|a(){}[0]
 }
+
 abstract interface examples.classes/I // examples.classes/I|null[0]
+
 abstract interface examples.classes/II // examples.classes/II|null[0]
+
 abstract class examples.classes/AC { // examples.classes/AC|null[0]
     constructor <init>() // examples.classes/AC.<init>|<init>(){}[0]
+
     abstract fun a() // examples.classes/AC.a|a(){}[0]
     final fun b() // examples.classes/AC.b|b(){}[0]
 }
+
 final class examples.classes/C { // examples.classes/C|null[0]
     constructor <init>(kotlin/Any) // examples.classes/C.<init>|<init>(kotlin.Any){}[0]
+
     final val v // examples.classes/C.v|{}v[0]
         final fun <get-v>(): kotlin/Any // examples.classes/C.v.<get-v>|<get-v>(){}[0]
+
     final fun m() // examples.classes/C.m|m(){}[0]
 }
+
 final class examples.classes/D { // examples.classes/D|null[0]
     constructor <init>(kotlin/Int) // examples.classes/D.<init>|<init>(kotlin.Int){}[0]
+
     final val x // examples.classes/D.x|{}x[0]
         final fun <get-x>(): kotlin/Int // examples.classes/D.x.<get-x>|<get-x>(){}[0]
+
     final fun component1(): kotlin/Int // examples.classes/D.component1|component1(){}[0]
     final fun copy(kotlin/Int =...): examples.classes/D // examples.classes/D.copy|copy(kotlin.Int){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // examples.classes/D.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // examples.classes/D.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // examples.classes/D.toString|toString(){}[0]
 }
+
 final class examples.classes/IC : examples.classes/II { // examples.classes/IC|null[0]
     constructor <init>() // examples.classes/IC.<init>|<init>(){}[0]
 }
+
 final class examples.classes/Outer { // examples.classes/Outer|null[0]
     constructor <init>() // examples.classes/Outer.<init>|<init>(){}[0]
+
     final class Nested { // examples.classes/Outer.Nested|null[0]
         constructor <init>() // examples.classes/Outer.Nested.<init>|<init>(){}[0]
+
         final enum class NE : kotlin/Enum<examples.classes/Outer.Nested.NE> { // examples.classes/Outer.Nested.NE|null[0]
             enum entry A // examples.classes/Outer.Nested.NE.A|null[0]
             enum entry B // examples.classes/Outer.Nested.NE.B|null[0]
             enum entry C // examples.classes/Outer.Nested.NE.C|null[0]
+
             final val entries // examples.classes/Outer.Nested.NE.entries|#static{}entries[0]
                 final fun <get-entries>(): kotlin.enums/EnumEntries<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.entries.<get-entries>|<get-entries>#static(){}[0]
+
             final fun valueOf(kotlin/String): examples.classes/Outer.Nested.NE // examples.classes/Outer.Nested.NE.valueOf|valueOf#static(kotlin.String){}[0]
             final fun values(): kotlin/Array<examples.classes/Outer.Nested.NE> // examples.classes/Outer.Nested.NE.values|values#static(){}[0]
         }
+
         final inner class Inner { // examples.classes/Outer.Nested.Inner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.Inner.<init>|<init>(){}[0]
         }
+
         final inner class YetAnotherInner { // examples.classes/Outer.Nested.YetAnotherInner|null[0]
             constructor <init>() // examples.classes/Outer.Nested.YetAnotherInner.<init>|<init>(){}[0]
         }
     }
 }
+
 open class examples.classes/OC { // examples.classes/OC|null[0]
     constructor <init>(kotlin/Int) // examples.classes/OC.<init>|<init>(kotlin.Int){}[0]
     constructor <init>(kotlin/Long) // examples.classes/OC.<init>|<init>(kotlin.Long){}[0]
     constructor <init>(kotlin/String) // examples.classes/OC.<init>|<init>(kotlin.String){}[0]
+
     final val ix // examples.classes/OC.ix|{}ix[0]
         final fun <get-ix>(): kotlin/Int // examples.classes/OC.ix.<get-ix>|<get-ix>(){}[0]
     final val iy // examples.classes/OC.iy|{}iy[0]
         final fun <get-iy>(): kotlin/Long // examples.classes/OC.iy.<get-iy>|<get-iy>(){}[0]
     final val iz // examples.classes/OC.iz|{}iz[0]
         final fun <get-iz>(): kotlin/String // examples.classes/OC.iz.<get-iz>|<get-iz>(){}[0]
+
     final var x // examples.classes/OC.x|{}x[0]
         final fun <get-x>(): kotlin/Int // examples.classes/OC.x.<get-x>|<get-x>(){}[0]
         final fun <set-x>(kotlin/Int) // examples.classes/OC.x.<set-x>|<set-x>(kotlin.Int){}[0]
@@ -102,27 +132,34 @@ open class examples.classes/OC { // examples.classes/OC|null[0]
     final var z // examples.classes/OC.z|{}z[0]
         final fun <get-z>(): kotlin/Int // examples.classes/OC.z.<get-z>|<get-z>(){}[0]
         final fun <set-z>(kotlin/Int) // examples.classes/OC.z.<set-z>|<set-z>(kotlin.Int){}[0]
+
     final fun c() // examples.classes/OC.c|c(){}[0]
     open fun o(): kotlin/Int // examples.classes/OC.o|o(){}[0]
 }
+
 final object examples.classes/O // examples.classes/O|null[0]
+
 final object examples.classes/OO // examples.classes/OO|null[0]
+
 final const val examples.classes/con // examples.classes/con|{}con[0]
     final fun <get-con>(): kotlin/String // examples.classes/con.<get-con>|<get-con>(){}[0]
 final const val examples.classes/intCon // examples.classes/intCon|{}intCon[0]
     final fun <get-intCon>(): kotlin/Int // examples.classes/intCon.<get-intCon>|<get-intCon>(){}[0]
+
 final val examples.classes/a // examples.classes/a|{}a[0]
     final fun <get-a>(): kotlin/Any // examples.classes/a.<get-a>|<get-a>(){}[0]
 final val examples.classes/i // examples.classes/i|{}i[0]
     final fun <get-i>(): kotlin/Int // examples.classes/i.<get-i>|<get-i>(){}[0]
 final val examples.classes/l // examples.classes/l|{}l[0]
     final fun <get-l>(): kotlin/Long // examples.classes/l.<get-l>|<get-l>(){}[0]
+
 final var examples.classes/d // examples.classes/d|{}d[0]
     final fun <get-d>(): kotlin/Double // examples.classes/d.<get-d>|<get-d>(){}[0]
     final fun <set-d>(kotlin/Double) // examples.classes/d.<set-d>|<set-d>(kotlin.Double){}[0]
 final var examples.classes/r // examples.classes/r|{}r[0]
     final fun <get-r>(): kotlin/Float // examples.classes/r.<get-r>|<get-r>(){}[0]
     final fun <set-r>(kotlin/Float) // examples.classes/r.<set-r>|<set-r>(kotlin.Float){}[0]
+
 final fun <#A: kotlin/Any?> examples.classes/consume(#A) // examples.classes/consume|consume(0:0){0§<kotlin.Any?>}[0]
 final fun examples.classes/testFun(): kotlin/Int // examples.classes/testFun|testFun(){}[0]
 final inline fun examples.classes/testInlineFun() // examples.classes/testInlineFun|testInlineFun(){}[0]

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarations.kt
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 JetBrains s.r.o.
+ * Copyright 2016-2024 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarationsAndroidOnly.kt
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarationsAndroidOnly.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package examples.classes
+
+public actual class Exp {
+    constructor(a: Int, b: Int) {
+
+    }
+
+    actual fun a(): Int = 1
+    actual fun b(): Int = 2
+    actual fun c(): Int = 3
+
+    actual var v1: Int = 1
+    actual var v2: Int = 2
+    actual var v3: Int = 3
+
+    actual val vi1: Int = 4
+    actual val vi2: Int = 5
+    actual val vi3: Int = 6
+}
+
+val androidAndLinuxVal: Int = 0
+
+class AndroidAndLinuxClass

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarationsExp.kt
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarationsExp.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package examples.classes
+
+public expect class Exp {
+    fun a(): Int
+    fun b(): Int
+    fun c(): Int
+
+    var v1: Int
+    var v2: Int
+    var v3: Int
+
+    val vi1: Int
+    val vi2: Int
+    val vi3: Int
+}

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarationsLinuxOnly.kt
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarationsLinuxOnly.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package examples.classes
+
+public fun linuxFun(): String = "123"
+public fun anotherLinuxFun(): Int = 42
+
+public class LinuxClass
+
+public actual class Exp {
+    constructor(a: Int, b: Int) {
+
+    }
+
+    actual fun a(): Int = 1
+    actual fun b(): Int = 2
+    actual fun c(): Int = 3
+    fun d(): Int = 4
+    fun e(): Int = 5
+
+    actual var v1: Int = 1
+    actual var v2: Int = 2
+    actual var v3: Int = 3
+    var v4: Int = 4
+
+    actual val vi1: Int = 4
+    actual val vi2: Int = 5
+    actual val vi3: Int = 6
+    val vi4: Int = 7
+}
+
+val androidAndLinuxVal: Int = 0
+val linuxVal: Int = 0
+
+class AndroidAndLinuxClass

--- a/src/functionalTest/resources/examples/classes/TopLevelDeclarationsMingwOnly.kt
+++ b/src/functionalTest/resources/examples/classes/TopLevelDeclarationsMingwOnly.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package examples.classes
+
+public actual class Exp {
+    constructor(a: Int, b: Int) {
+
+    }
+
+    actual fun a(): Int = 1
+    actual fun b(): Int = 2
+    actual fun c(): Int = 3
+    fun e(): Int = 5
+    fun f(): Int = 6
+
+    actual var v1: Int = 1
+    actual var v2: Int = 2
+    actual var v3: Int = 3
+
+    actual val vi1: Int = 4
+    actual val vi2: Int = 5
+    actual val vi3: Int = 6
+    val vi5: Int = 7
+}

--- a/src/main/kotlin/api/klib/KlibAbiDumpFileMerger.kt
+++ b/src/main/kotlin/api/klib/KlibAbiDumpFileMerger.kt
@@ -371,9 +371,7 @@ internal class KlibAbiDumpMerger {
         headerContent.forEach {
             appendable.append(it).append('\n')
         }
-        topLevelDeclaration.children.values.sortedWith(DeclarationsComparator).forEach {
-            it.dump(appendable, _targets, formatter)
-        }
+        topLevelDeclaration.dump(appendable, _targets, formatter)
     }
 
     private fun createFormatter(): KlibsTargetsFormatter {
@@ -504,13 +502,17 @@ internal class DeclarationContainer(val text: String, val parent: DeclarationCon
     }
 
     fun dump(appendable: Appendable, allTargets: Set<KlibTarget>, formatter: KlibsTargetsFormatter) {
-        if (targets != allTargets/* && !dumpFormat.singleTargetDump*/) {
+        if (targets != allTargets) {
             // Use the same indentation for target list as for the declaration itself
             appendable.append(" ".repeat(text.depth() * INDENT_WIDTH))
                 .append(formatter.formatDeclarationTargets(targets))
                 .append('\n')
         }
-        appendable.append(text).append('\n')
+        appendable.append(text)
+        // The text is empty for the fake top-level declaration
+        if (text.isNotEmpty()) {
+            appendable.append('\n')
+        }
         children.values.sortedWith(DeclarationsComparator).forEach {
             it.dump(appendable, this.targets, formatter)
         }
@@ -563,6 +565,7 @@ internal class DeclarationContainer(val text: String, val parent: DeclarationCon
                 null -> {
                     children[otherChild.key] = otherChild.value.deepCopy(this)
                 }
+
                 else -> child.mergeTargetSpecific(otherChild.value)
             }
         }

--- a/src/main/kotlin/api/klib/KlibAbiDumpFileMerger.kt
+++ b/src/main/kotlin/api/klib/KlibAbiDumpFileMerger.kt
@@ -513,11 +513,34 @@ internal class DeclarationContainer(val text: String, val parent: DeclarationCon
         if (text.isNotEmpty()) {
             appendable.append('\n')
         }
-        children.values.sortedWith(DeclarationsComparator).forEach {
-            it.dump(appendable, this.targets, formatter)
+        var previousDeclaration: DeclarationContainer? = null
+        children.values.sortedWith(DeclarationsComparator).forEach { currentDeclaration ->
+            if (previousDeclaration != null) {
+                val pd = previousDeclaration!!
+                // Precede a group of declarations sharing the same kind (properties, classes, functions),
+                // and declarations that'll have a "// Targets" header with a newline to improve readability.
+                if (pd.type != currentDeclaration.type || currentDeclaration.targets != this.targets
+                    || currentDeclaration.isTypeDeclaration()
+                ) {
+                    appendable.append('\n')
+                }
+            }
+            currentDeclaration.dump(appendable, this.targets, formatter)
+            previousDeclaration = currentDeclaration
         }
         if (delimiter != null) {
             appendable.append(delimiter).append('\n')
+        }
+    }
+
+    private fun isTypeDeclaration(): Boolean {
+        return when (type) {
+            DeclarationType.Object -> true
+            DeclarationType.Class -> true
+            DeclarationType.Interface -> true
+            DeclarationType.AnnotationClass -> true
+            DeclarationType.EnumClass -> true
+            else -> false
         }
     }
 

--- a/src/test/kotlin/samples/KlibDumpSamples.kt
+++ b/src/test/kotlin/samples/KlibDumpSamples.kt
@@ -87,10 +87,13 @@ class KlibDumpSamples {
             // Library unique name: <org.example:bcv-klib-test>
             final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
                 constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
                 final val value // org.example/ShardedClass.value|{}value[0]
                     final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
                 final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
             }
+
             // Targets: [linuxX64]
             final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
             
@@ -155,10 +158,13 @@ class KlibDumpSamples {
             // Library unique name: <org.example:bcv-klib-test>
             final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
                 constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
                 final val value // org.example/ShardedClass.value|{}value[0]
                     final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
                 final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
             }
+
             // Targets: [linuxX64.linuxX86_64]
             final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
             
@@ -177,8 +183,10 @@ class KlibDumpSamples {
             // Library unique name: <org.example:bcv-klib-test>
             final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
                 constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
                 final val value // org.example/ShardedClass.value|{}value[0]
                     final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
                 final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
             }
             
@@ -199,6 +207,7 @@ class KlibDumpSamples {
 
             // Library unique name: <testproject>
             abstract class examples.classes/Klass // examples.classes/Klass|null[0]            
+
             // Targets: [iosArm64, iosX64]
             abstract interface examples.classes/Iface // examples.classes/Iface|null[0]
 
@@ -244,6 +253,7 @@ class KlibDumpSamples {
 
             // Library unique name: <testproject>
             abstract class examples.classes/Klass // examples.classes/Klass|null[0]
+
             // Targets: [iosArm64]
             abstract interface examples.classes/Iface // examples.classes/Iface|null[0]
 
@@ -282,6 +292,7 @@ class KlibDumpSamples {
 
             // Library unique name: <testproject>
             abstract interface examples.classes/Iface // examples.classes/Iface|null[0]
+
             abstract class examples.classes/NewKlass // examples.classes/NewKlass|null[0]
 
         """.trimIndent(),

--- a/src/test/kotlin/tests/KlibDumpTest.kt
+++ b/src/test/kotlin/tests/KlibDumpTest.kt
@@ -48,10 +48,13 @@ private val mergedLinuxDump = """
     // Library unique name: <org.example:bcv-klib-test>
     final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
         constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
         final val value // org.example/ShardedClass.value|{}value[0]
             final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
         final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
     }
+
     final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
 
 """.trimIndent()
@@ -68,15 +71,20 @@ private val mergedLinuxDumpWithTargetSpecificDeclaration = """
     // Library unique name: <org.example:bcv-klib-test>
     final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
         constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
         final val value // org.example/ShardedClass.value|{}value[0]
             final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
         // Targets: [linuxArm64]
         final fun add2(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
+
         // Targets: [linuxX64]
         final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
     }
+
     // Targets: [linuxArm64]
     final fun org.example/ShardedClass2(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
+
     // Targets: [linuxX64]
     final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
 
@@ -93,10 +101,13 @@ private val mergedLinuxArm64Dump = """
     // Library unique name: <org.example:bcv-klib-test>
     final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
         constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
         final val value // org.example/ShardedClass.value|{}value[0]
             final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
         final fun add2(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
     }
+
     final fun org.example/ShardedClass2(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
 
 """.trimIndent()
@@ -112,10 +123,13 @@ private val mergedLinuxDumpWithCustomName = """
     // Library unique name: <org.example:bcv-klib-test>
     final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
         constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
         final val value // org.example/ShardedClass.value|{}value[0]
             final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
         final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
     }
+
     final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
 
 """.trimIndent()
@@ -590,14 +604,19 @@ class KlibDumpTest {
             // Library unique name: <testproject>
             final class org.different.pack/BuildConfig { // org.different.pack/BuildConfig|null[0]
                 constructor <init>() // org.different.pack/BuildConfig.<init>|<init>(){}[0]
+
                 final val p1 // org.different.pack/BuildConfig.p1|{}p1[0]
                     final fun <get-p1>(): kotlin/Int // org.different.pack/BuildConfig.p1.<get-p1>|<get-p1>(){}[0]
+
                 final fun f1(): kotlin/Int // org.different.pack/BuildConfig.f1|f1(){}[0]
             }
+
             // Targets: [androidNative, linux]
             final fun (org.different.pack/BuildConfig).org.different.pack/linuxArm64Specific3(): kotlin/Int // org.different.pack/linuxArm64Specific3|linuxArm64Specific@org.different.pack.BuildConfig(){}[0]
+
             // Targets: [linux]
             final fun (org.different.pack/BuildConfig).org.different.pack/linuxArm64Specific2(): kotlin/Int // org.different.pack/linuxArm64Specific2|linuxArm64Specific@org.different.pack.BuildConfig(){}[0]
+
             // Targets: [androidNativeArm64]
             final fun (org.different.pack/BuildConfig).org.different.pack/linuxArm64Specific(): kotlin/Int // org.different.pack/linuxArm64Specific|linuxArm64Specific@org.different.pack.BuildConfig(){}[0]
 
@@ -638,6 +657,7 @@ class KlibDumpTest {
             
             // Library unique name: <testproject>
             final fun org.example/common(): kotlin/Int // com.example/common|common(){}[0]
+
             // Targets: [ios]
             final fun org.example/native(): kotlin/Int // com.example/native|native(){}[0]
             

--- a/src/test/kotlin/tests/KlibDumpTest.kt
+++ b/src/test/kotlin/tests/KlibDumpTest.kt
@@ -758,56 +758,77 @@ class KlibDumpTest {
             open annotation class ann/A : kotlin/Annotation { // ann/A|null[0]
                 constructor <init>() // ann/A.<init>|<init>(){}[0]
             }
+            
             open annotation class ann/B : kotlin/Annotation { // ann/B|null[0]
                 constructor <init>() // ann/B.<init>|<init>(){}[0]
             }
+            
             final enum class a/E : kotlin/Enum<a/E> { // a/eE|null[0]
                 enum entry A // a/E.A|null[0]            
                 enum entry B // a/E.B|null[0]
                 enum entry C // a/E.C|null[0]
             }
+            
             abstract interface an.iface/I // an.iface/I|null[0]
+            
             abstract interface iface/I // iface/I|null[0]
+            
             abstract class cls/C // cls/C|null[0]
+            
             final class cls/A // cls/A|null[0]
+            
             final class cls/B { // cls/B|null[0]
                 constructor <init>() // cls/B.<init>|<init>(){}[0]
                 constructor <init>(kotlin/Int) // cls/B.<init>|<init>(kotlin.Int){}[0]
+            
                 final val x // cls/B.x|{}x[0]
                     final fun <get-x>(): kotlin/Int // cls/B.x.<get-x>|<get-x>(){}[0]
                 final val y // cls/B.y|{}y[0]
                     final fun <get-y>(): kotlin/Int // cls/B.y.<get-y>|<get-y>(){}[0]
+            
                 final var aaa // cls/B.aaa|{}aaa[0]
                     final fun <get-aaa>(): kotlin/Int // cls/B.aaa.<get-aaa>|<get-aaa>(){}[0]
                     final fun <set-aaa>(kotlin/Int) // cls/B.aaa.<set-aaa>|<set-aaa>(kotlin.Int){}[0]
                 final var yy // cls/B.yy|{}yy[0]
                     final fun <get-yy>(): kotlin/Int // cls/B.yy.<get-yy>|<get-yy>(){}[0]
                     final fun <set-yy>(kotlin/Int) // cls/B.yy.<set-yy>|<set-yy>(kotlin.Int){}[0]
+            
                 final fun a(): kotlin/Int // cls/B.a|a(){}[0]
                 final fun b(): kotlin/Int // cls/B.b|b(){}[0]
                 final fun c(): kotlin/Int // cls/B.c|c(){}[0]
+            
                 final class A // cls/B.A|null[0]
+            
                 final class N // cls/B.N|null[0]
+            
                 final inner class I1 // cls/B.I1|null[0]
+            
                 final inner class I2 // cls/B.I2|null[0]
             }
+            
             final class cls/D // cls/D|null[0]
+            
             final object a/O // a/O|null[0]
+            
             final object a/OO // a/OO|null[0]
+            
             final const val c/acon // c/acon|{}acon[0]
                 final fun <get-acon>(): kotlin/String // c/acon.<get-acon>|<get-acon>(){}[0]
             final const val c/con // c/con|{}con[0]
                 final fun <get-con>(): kotlin/String // c/con.<get-con>|<get-con>(){}[0]
+            
             final val v/a // v/a|{}a[0]
                 final fun <get-a>(): kotlin/Long // v/a.<get-a>|<get-a>(){}[0]
             final val v/l // v/l|{}l[0]
                 final fun <get-l>(): kotlin/Long // v/l.<get-l>|<get-l>(){}[0]
+            
             final var v/d // v/d|{}d[0]
                 final fun <get-d>(): kotlin/Double // v/d.<get-d>|<get-d>(){}[0]
                 final fun <set-d>(kotlin/Double) // v/d.<set-d>|<set-d>(kotlin.Double){}[0]
             final var v/e // v/e|{}d[0]
                 final fun <get-e>(): kotlin/Double // v/d.<get-e>|<get-e>(){}[0]
                 final fun <set-e>(kotlin/Double) // v/e.<set-e>|<set-e>(kotlin.Double){}[0]
+            
             final fun f/a: kotlin/Int // f/a|a(){}[0]
             final fun f/b: kotlin/Int // f/b|b(){}[0]
             

--- a/src/test/resources/merge/diverging/linuxArm64.extracted.api
+++ b/src/test/resources/merge/diverging/linuxArm64.extracted.api
@@ -8,10 +8,13 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }
+
 final fun (kotlin/Long).org.example/add(kotlin/Long): kotlin/Long // org.example/add|add@kotlin.Long(kotlin.Long){}[0]
 final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
 final fun org.example/add(kotlin/Long, kotlin/Long): kotlin/Long // org.example/add|add(kotlin.Long;kotlin.Long){}[0]

--- a/src/test/resources/merge/diverging/merged.abi
+++ b/src/test/resources/merge/diverging/merged.abi
@@ -9,24 +9,34 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }
+
 final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
+
 // Targets: [linux]
 final fun (kotlin/Long).org.example/add(kotlin/Long): kotlin/Long // org.example/add|add@kotlin.Long(kotlin.Long){}[0]
+
 // Targets: [linux]
 final fun org.example/add(kotlin/Long, kotlin/Long): kotlin/Long // org.example/add|add(kotlin.Long;kotlin.Long){}[0]
+
 // Targets: [androidNativeArm64]
 final class org.example/X { // org.example/X|null[0]
     constructor <init>(kotlin/Int) // org.example/X.<init>|<init>(kotlin.Int){}[0]
 }
+
 // Targets: [androidNativeArm64]
 final fun (org.example/X).org.example/add(org.example/X): org.example/X // org.example/add|add@org.example.X(org.example.X){}[0]
+
 // Targets: [androidNativeArm64]
 final fun org.example/add(org.example/X, org.example/X): org.example/X // org.example/add|add(org.example.X;org.example.X){}[0]
+
 // Targets: [tvosX64]
 final fun (kotlin/Int).org.example/add(kotlin/Int): kotlin/Int // org.example/add|add@kotlin.Int(kotlin.Int){}[0]
+
 // Targets: [tvosX64]
 final fun org.example/add(kotlin/Int, kotlin/Int): kotlin/Int // org.example/add|add(kotlin.Int;kotlin.Int){}[0]

--- a/src/test/resources/merge/diverging/merged_with_aliases.abi
+++ b/src/test/resources/merge/diverging/merged_with_aliases.abi
@@ -9,24 +9,34 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }
+
 final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
+
 // Targets: [linux]
 final fun (kotlin/Long).org.example/add(kotlin/Long): kotlin/Long // org.example/add|add@kotlin.Long(kotlin.Long){}[0]
+
 // Targets: [linux]
 final fun org.example/add(kotlin/Long, kotlin/Long): kotlin/Long // org.example/add|add(kotlin.Long;kotlin.Long){}[0]
+
 // Targets: [androidNativeArm64]
 final class org.example/X { // org.example/X|null[0]
     constructor <init>(kotlin/Int) // org.example/X.<init>|<init>(kotlin.Int){}[0]
 }
+
 // Targets: [androidNativeArm64]
 final fun (org.example/X).org.example/add(org.example/X): org.example/X // org.example/add|add@org.example.X(org.example.X){}[0]
+
 // Targets: [androidNativeArm64]
 final fun org.example/add(org.example/X, org.example/X): org.example/X // org.example/add|add(org.example.X;org.example.X){}[0]
+
 // Targets: [tvosX64]
 final fun (kotlin/Int).org.example/add(kotlin/Int): kotlin/Int // org.example/add|add@kotlin.Int(kotlin.Int){}[0]
+
 // Targets: [tvosX64]
 final fun org.example/add(kotlin/Int, kotlin/Int): kotlin/Int // org.example/add|add(kotlin.Int;kotlin.Int){}[0]

--- a/src/test/resources/merge/diverging/merged_with_aliases_and_custom_names.abi
+++ b/src/test/resources/merge/diverging/merged_with_aliases_and_custom_names.abi
@@ -9,24 +9,34 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }
+
 final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
+
 // Targets: [linux]
 final fun (kotlin/Long).org.example/add(kotlin/Long): kotlin/Long // org.example/add|add@kotlin.Long(kotlin.Long){}[0]
+
 // Targets: [linux]
 final fun org.example/add(kotlin/Long, kotlin/Long): kotlin/Long // org.example/add|add(kotlin.Long;kotlin.Long){}[0]
+
 // Targets: [androidNativeArm64.android]
 final class org.example/X { // org.example/X|null[0]
     constructor <init>(kotlin/Int) // org.example/X.<init>|<init>(kotlin.Int){}[0]
 }
+
 // Targets: [androidNativeArm64.android]
 final fun (org.example/X).org.example/add(org.example/X): org.example/X // org.example/add|add@org.example.X(org.example.X){}[0]
+
 // Targets: [androidNativeArm64.android]
 final fun org.example/add(org.example/X, org.example/X): org.example/X // org.example/add|add(org.example.X;org.example.X){}[0]
+
 // Targets: [tvosX64]
 final fun (kotlin/Int).org.example/add(kotlin/Int): kotlin/Int // org.example/add|add@kotlin.Int(kotlin.Int){}[0]
+
 // Targets: [tvosX64]
 final fun org.example/add(kotlin/Int, kotlin/Int): kotlin/Int // org.example/add|add(kotlin.Int;kotlin.Int){}[0]

--- a/src/test/resources/merge/guess/common.api
+++ b/src/test/resources/merge/guess/common.api
@@ -8,7 +8,9 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }

--- a/src/test/resources/merge/guess/guessed.api
+++ b/src/test/resources/merge/guess/guessed.api
@@ -8,10 +8,13 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
     final fun addNarrow(kotlin/Int): kotlin/Int // org.example/ShardedClass.addNarrow|addNarrow(kotlin.Int){}[0]
 }
+
 final fun (org.example/X).org.example/add(org.example/X): org.example/X // org.example/add|add@org.example.X(org.example.X){}[0]
 final fun org.example/add(org.example/X, org.example/X): org.example/X // org.example/add|add(org.example.X;org.example.X){}[0]

--- a/src/test/resources/merge/guess/linuxArm64Specific.api
+++ b/src/test/resources/merge/guess/linuxArm64Specific.api
@@ -9,5 +9,6 @@
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     final fun addNarrow(kotlin/Int): kotlin/Int // org.example/ShardedClass.addNarrow|addNarrow(kotlin.Int){}[0]
 }
+
 final fun (org.example/X).org.example/add(org.example/X): org.example/X // org.example/add|add@org.example.X(org.example.X){}[0]
 final fun org.example/add(org.example/X, org.example/X): org.example/X // org.example/add|add(org.example.X;org.example.X){}[0]

--- a/src/test/resources/merge/idempotent/bcv-klib-test.abi
+++ b/src/test/resources/merge/idempotent/bcv-klib-test.abi
@@ -11,24 +11,34 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }
+
 final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]
+
 // Targets: [apple]
 final fun (kotlin/Int).org.example/add(kotlin/Int): kotlin/Int // org.example/add|add@kotlin.Int(kotlin.Int){}[0]
+
 // Targets: [apple]
 final fun org.example/add(kotlin/Int, kotlin/Int): kotlin/Int // org.example/add|add(kotlin.Int;kotlin.Int){}[0]
+
 // Targets: [androidNative]
 final class org.example/X { // org.example/X|null[0]
     constructor <init>(kotlin/Int) // org.example/X.<init>|<init>(kotlin.Int){}[0]
 }
+
 // Targets: [androidNative]
 final fun (org.example/X).org.example/add(org.example/X): org.example/X // org.example/add|add@org.example.X(org.example.X){}[0]
+
 // Targets: [androidNative]
 final fun org.example/add(org.example/X, org.example/X): org.example/X // org.example/add|add(org.example.X;org.example.X){}[0]
+
 // Targets: [linux]
 final fun (kotlin/Long).org.example/add(kotlin/Long): kotlin/Long // org.example/add|add@kotlin.Long(kotlin.Long){}[0]
+
 // Targets: [linux]
 final fun org.example/add(kotlin/Long, kotlin/Long): kotlin/Long // org.example/add|add(kotlin.Long;kotlin.Long){}[0]

--- a/src/test/resources/merge/identical/merged.abi
+++ b/src/test/resources/merge/identical/merged.abi
@@ -8,8 +8,11 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }
+
 final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]

--- a/src/test/resources/merge/non-overlapping/merged.klib.abi
+++ b/src/test/resources/merge/non-overlapping/merged.klib.abi
@@ -8,5 +8,6 @@
 // Library unique name: <org.example:bcv-klib-test>
 // Targets: [linuxArm64]
 final fun org.example/add(kotlin/Long, kotlin/Long): kotlin/Long // org.example/add|add(kotlin.Long;kotlin.Long){}[0]
+
 // Targets: [linuxX64]
 final fun org.example/sub(kotlin/Long, kotlin/Long): kotlin/Long // org.example/sub|sub(kotlin.Long;kotlin.Long){}[0]

--- a/src/test/resources/merge/parseNarrowChildrenDecls/withoutLinuxAll.abi
+++ b/src/test/resources/merge/parseNarrowChildrenDecls/withoutLinuxAll.abi
@@ -8,7 +8,9 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }

--- a/src/test/resources/merge/parseNarrowChildrenDecls/withoutLinuxArm64.abi
+++ b/src/test/resources/merge/parseNarrowChildrenDecls/withoutLinuxArm64.abi
@@ -8,9 +8,12 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
+
     // Targets: [linuxX64]
     final fun addNarrow(kotlin/Int): kotlin/Int // org.example/ShardedClass.addNarrow|addNarrow(kotlin.Int){}[0]
 }

--- a/src/test/resources/merge/webTargets/js.ext.abi
+++ b/src/test/resources/merge/webTargets/js.ext.abi
@@ -8,8 +8,11 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }
+
 final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]

--- a/src/test/resources/merge/webTargets/merged.abi
+++ b/src/test/resources/merge/webTargets/merged.abi
@@ -8,8 +8,11 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }
+
 final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]

--- a/src/test/resources/merge/webTargets/wasmJs.ext.abi
+++ b/src/test/resources/merge/webTargets/wasmJs.ext.abi
@@ -8,8 +8,11 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }
+
 final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]

--- a/src/test/resources/merge/webTargets/wasmWasi.ext.abi
+++ b/src/test/resources/merge/webTargets/wasmWasi.ext.abi
@@ -8,8 +8,11 @@
 // Library unique name: <org.example:bcv-klib-test>
 final class org.example/ShardedClass { // org.example/ShardedClass|null[0]
     constructor <init>(kotlin/Int) // org.example/ShardedClass.<init>|<init>(kotlin.Int){}[0]
+
     final val value // org.example/ShardedClass.value|{}value[0]
         final fun <get-value>(): kotlin/Int // org.example/ShardedClass.value.<get-value>|<get-value>(){}[0]
+
     final fun add(kotlin/Int): kotlin/Int // org.example/ShardedClass.add|add(kotlin.Int){}[0]
 }
+
 final fun org.example/ShardedClass(kotlin/Int, kotlin/Float, kotlin/Long): org.example/ShardedClass // org.example/ShardedClass|ShardedClass(kotlin.Int;kotlin.Float;kotlin.Long){}[0]


### PR DESCRIPTION
Additional newlines should improve dump's readability and also improve diffs generated by the GH.

This change builds on #197, which groups declarations based on their kind.

Now, an extra newline will always be inserted before:
-  `// Targets: ` meta-header, 
- a new class/interface/object/enum-class declaration
- in-between two declarations having different kinds (for example, between a group of `vars` and `funs`).

Closes #196 