### PR TITLE
allow apiDumpDirectory to be outside project dir as long as inside rootProject dir

### DIFF
--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -162,13 +162,15 @@ private class TargetConfig constructor(
     private val apiDirProvider = project.provider {
         val dir = extension.apiDumpDirectory
 
-        val root = project.layout.projectDirectory.asFile.toPath().toAbsolutePath().normalize()
+        
+        val root = project.rootProject.layout.projectDirectory.asFile.toPath().toAbsolutePath().normalize()
         val resolvedDir = root.resolve(dir).normalize()
         if (!resolvedDir.startsWith(root)) {
+            val rootName = if (project.rootProject == project) "project" else "rootProject"
             throw IllegalArgumentException(
-                "apiDumpDirectory (\"$dir\") should be inside the project directory, " +
-                        "but it resolves to a path outside the project root.\n" +
-                        "Project's root path: $root\nResolved apiDumpDirectory: $resolvedDir"
+                "apiDumpDirectory (\"$dir\") should be inside the $rootName directory, " +
+                        "but it resolves to a path outside the $rootName root.\n" +
+                        "Root path: $root\nResolved apiDumpDirectory: $resolvedDir"
             )
         }
 


### PR DESCRIPTION
Shall be understood as pre-work, I guess that there are test which will fail now (as the check changed) and additional tests would be good which still ensure that we cannot write outside the rootProject dir.

This change allows that e.g. in an multimodule project all api files are written to a single place within the rootProject dir (in my case I would like to put everything into rootProjectDir/misc/api and use `apiDumpDirectory = rootProject.projectDir.relativeTo(project.projectDir).resolve("misc/api").toString()`