### PR TITLE
Use foojay-resolver-convention to resolve JVM toolchains

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ import kotlinx.validation.build.mavenRepositoryPublishing
 import kotlinx.validation.build.signPublicationIfKeyPresent
 import org.gradle.api.attributes.TestSuiteType.FUNCTIONAL_TEST
 import org.jetbrains.dokka.gradle.DokkaTask
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import java.net.URL
@@ -101,9 +100,10 @@ tasks.compileKotlin {
 java {
     withJavadocJar()
     withSourcesJar()
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
-    }
+}
+
+kotlin {
+    jvmToolchain(8)
 }
 
 tasks.compileTestKotlin {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,13 +1,16 @@
 /*
- * Copyright 2016-2020 JetBrains s.r.o.
+ * Copyright 2016-2024 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
-import java.util.Properties
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `kotlin-dsl`
+}
+
+kotlin {
+    jvmToolchain(8)
 }
 
 dependencies {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -13,6 +13,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention")
+}
+
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
 

--- a/buildSrc/src/main/kotlin/conventions/java-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/java-base.gradle.kts
@@ -10,9 +10,6 @@ plugins {
 }
 
 java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
-    }
     withSourcesJar()
     withJavadocJar()
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 JetBrains s.r.o.
+ * Copyright 2016-2024 JetBrains s.r.o.
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 import org.gradle.api.initialization.resolve.RepositoriesMode.PREFER_SETTINGS
@@ -12,6 +12,10 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version ("0.8.0")
 }
 
 @Suppress("UnstableApiUsage")


### PR DESCRIPTION
Recently, I was running BCV tests on hosts with only recent Java installed, and automatic toolchain provisioning could made my life much easier.