### PR TITLE
Require JVM ABI dump presence in empty KMP projects

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultiPlatformSingleJvmTargetTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultiPlatformSingleJvmTargetTest.kt
@@ -129,8 +129,8 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
         }
 
         runner.build().apply {
-            assertTaskSkipped(":jvmApiDump")
-            assertTaskUpToDate(":apiDump")
+            assertTaskSuccess(":jvmApiDump")
+            assertTaskSuccess(":apiDump")
         }
     }
 
@@ -149,9 +149,28 @@ internal class MultiPlatformSingleJvmTargetTest : BaseKotlinGradleTest() {
         }
 
         runner.build().apply {
-            assertTaskSkipped(":jvmApiCheck")
-            assertTaskUpToDate(":apiCheck")
+            assertTaskSuccess(":jvmApiCheck")
+            assertTaskSuccess(":apiCheck")
+        }
+    }
 
+    @Test
+    fun testApiCheckFailsForEmptyProjectWithoutDumpFile() {
+        val runner = test {
+            buildGradleKts {
+                resolve("/examples/gradle/base/multiplatformWithSingleJvmTarget.gradle.kts")
+            }
+
+            runner {
+                arguments.add(":apiCheck")
+            }
+        }
+
+        runner.buildAndFail().apply {
+            assertTaskFailure(":jvmApiCheck")
+            assertThat(output).contains(
+                "Expected file with API declarations 'api${File.separator}${rootProjectDir.name}.api' does not exist"
+            )
         }
     }
 

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -214,7 +214,6 @@ private fun Project.configureKotlinCompilation(
     val apiBuildDir = apiDirProvider.flatMap { f -> layout.buildDirectory.asFile.map { it.resolve(f) } }
 
     val apiBuild = task<KotlinApiBuildTask>(targetConfig.apiTaskName("Build")) {
-        // Do not enable task for empty umbrella modules
         isEnabled = apiCheckEnabled(projectName, extension)
         // 'group' is not specified deliberately, so it will be hidden from ./gradlew tasks
         description =
@@ -562,7 +561,6 @@ private class KlibValidationPipelineBuilder(
     ): TaskProvider<KotlinKlibAbiBuildTask> {
         val projectName = project.name
         val buildTask = project.task<KotlinKlibAbiBuildTask>(targetConfig.apiTaskName("Build")) {
-            // Do not enable task for empty umbrella modules
             isEnabled = klibAbiCheckEnabled(projectName, extension)
             // 'group' is not specified deliberately, so it will be hidden from ./gradlew tasks
             description = "Builds Kotlin KLib ABI dump for 'main' compilations of $projectName. " +

--- a/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
+++ b/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt
@@ -215,7 +215,7 @@ private fun Project.configureKotlinCompilation(
 
     val apiBuild = task<KotlinApiBuildTask>(targetConfig.apiTaskName("Build")) {
         // Do not enable task for empty umbrella modules
-        isEnabled = apiCheckEnabled(projectName, extension) && compilation.hasAnySources()
+        isEnabled = apiCheckEnabled(projectName, extension)
         // 'group' is not specified deliberately, so it will be hidden from ./gradlew tasks
         description =
             "Builds Kotlin API for 'main' compilations of $projectName. Complementary task and shouldn't be called manually"
@@ -631,7 +631,3 @@ private val Project.jvmDumpFileName: String
     get() = "$name.api"
 private val Project.klibDumpFileName: String
     get() = "$name.klib.api"
-
-private fun KotlinCompilation<KotlinCommonOptions>.hasAnySources(): Boolean = allKotlinSourceSets.any {
-    it.kotlin.srcDirs.any(File::exists)
-}


### PR DESCRIPTION
Currently, only JVM ABI validation in KMP projects allows having no dump file. In other cases (JVM ABI validation in K/JVM project or KLib validation) require the presence of an ABI dump file. Lack of such a file is treated as a validation error.

The main motivation for having a dump files instead of simply ignoring such projects is that otherwise BCV won't be able to catch the case when all sources were removed from a project.

Fixes #243