### PR TITLE
Align klib validation behavior for empty projects with other targets

### DIFF
--- a/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
+++ b/src/functionalTest/kotlin/kotlinx/validation/test/MultipleJvmTargetsTest.kt
@@ -124,8 +124,6 @@ internal class MultipleJvmTargetsTest : BaseKotlinGradleTest() {
             assertTaskSuccess(":jvmApiDump")
             assertTaskSuccess(":anotherJvmApiDump")
 
-            System.err.println(output)
-
             val anotherExpectedApi = readFileList("/examples/classes/Subsub1Class.dump")
             assertThat(anotherApiDump.readText()).isEqualToIgnoringNewLines(anotherExpectedApi)
 

--- a/src/main/kotlin/-Utils.kt
+++ b/src/main/kotlin/-Utils.kt
@@ -56,7 +56,6 @@ public class KlibDumpMetadata(
      * Instead, a dependent task will be skipped.
      */
     @get:InputFiles
-    @get:SkipWhenEmpty
     @get:PathSensitive(PathSensitivity.RELATIVE)
     public val dumpFile: RegularFileProperty
 ) : Serializable

--- a/src/main/kotlin/-Utils.kt
+++ b/src/main/kotlin/-Utils.kt
@@ -53,7 +53,8 @@ public class KlibDumpMetadata(
      * happen for an empty project, a project having only test targets,
      * or a project that has no sources for a particular target),
      * [KlibDumpMetadata] will not force an error.
-     * Instead, a dependent task will be skipped.
+     * It's up to [KlibDumpMetadata] users to check if a [dumpFile] exists and
+     * perform a required action accordingly.
      */
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)

--- a/src/main/kotlin/KotlinKlibExtractAbiTask.kt
+++ b/src/main/kotlin/KotlinKlibExtractAbiTask.kt
@@ -13,6 +13,8 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 /**
  * Extracts dump for targets supported by the host compiler from a merged API dump stored in a project.
@@ -58,7 +60,8 @@ public abstract class KotlinKlibExtractAbiTask : DefaultTask() {
                     "Please ensure that ':apiDump' was executed in order to get API dump to compare the build against")
         }
         if (inputFile.length() == 0L) {
-            error("Project ABI file ${inputFile.relativeTo(rootDir)} is empty.")
+            Files.copy(inputFile.toPath(), outputAbiFile.asFile.get().toPath(), StandardCopyOption.REPLACE_EXISTING)
+            return
         }
         val dump = KlibDump.from(inputFile)
         val unsupportedTargets = targetsToRemove.get().map(KlibTarget::targetName).toSet()

--- a/src/main/kotlin/KotlinKlibMergeAbiTask.kt
+++ b/src/main/kotlin/KotlinKlibMergeAbiTask.kt
@@ -20,8 +20,7 @@ public abstract class KotlinKlibMergeAbiTask : DefaultTask() {
     /**
      * Dumps to merge.
      *
-     * If a file referred by [KlibDumpMetadata.dumpFile] does not exist, it will be ignored and corresponding
-     * target will not be mentioned in the resulting merged dump.
+     * If there is no dump for a particular target, its [KlibDumpMetadata.dumpFile] won't exist.
      */
     @get:Nested
     public abstract val dumps: SetProperty<KlibDumpMetadata>


### PR DESCRIPTION
After #243 resolution, JVM/JVM on KMP/KMP projects validation behavior remained different for projects without non-test sources or without published API:
- For JVM projects (of all kinds), we generate empty dump files and verify that the dump remained empty on `apiCheck` execution;
- For KMP KLib-targets, dump generation is skipped for such projects; the validation fails due to a missing dump file.

This PR addresses #246 and aligns KMP validation behavior for empty projects with how JVM ABI validation works for them.