### PR TITLE
Postpone static field's companion resolution

### DIFF
--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -144,7 +144,7 @@ private fun FieldNode.buildFieldSignature(
             /*
              * In certain cases (like with enum entries), the fact a field is both static and final does not
              * imply it belongs to a companion object.
-             * We don't update field's the `companionClass` until we're 100% sure the field was
+             * We don't update field's `companionClass` until we're 100% sure the field was
              * actually moved from the companion.
              */
             companionClass = companionClassCandidate

--- a/src/main/kotlin/api/KotlinSignaturesLoading.kt
+++ b/src/main/kotlin/api/KotlinSignaturesLoading.kt
@@ -140,14 +140,11 @@ private fun FieldNode.buildFieldSignature(
              *
              * See https://github.com/Kotlin/binary-compatibility-validator/issues/90
              */
-            foundAnnotations.addAll(companionClassCandidate.methods.annotationsFor(property.syntheticMethodForAnnotations))
-            /*
-             * In certain cases (like with enum entries), the fact a field is both static and final does not
-             * imply it belongs to a companion object.
-             * We don't update field's `companionClass` until we're 100% sure the field was
-             * actually moved from the companion.
-             */
-            companionClass = companionClassCandidate
+            foundAnnotations.addAll(
+                companionClassCandidate.methods.annotationsFor(
+                    property.syntheticMethodForAnnotations
+                )
+            )
         }
     }
 

--- a/src/test/kotlin/cases/enums/EnumWithInternalCompanion.kt
+++ b/src/test/kotlin/cases/enums/EnumWithInternalCompanion.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2016-2024 JetBrains s.r.o.
+ * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
+ */
+
+package cases.enums
+
+public enum class EnumWithInternalCompanion {
+    A, B;
+
+    internal companion object
+}

--- a/src/test/kotlin/cases/enums/enums.txt
+++ b/src/test/kotlin/cases/enums/enums.txt
@@ -11,6 +11,14 @@ public final class cases/enums/EnumClass : java/lang/Enum {
 	public static fun values ()[Lcases/enums/EnumClass;
 }
 
+public final class cases/enums/EnumWithInternalCompanion : java/lang/Enum {
+	public static final field A Lcases/enums/EnumWithInternalCompanion;
+	public static final field B Lcases/enums/EnumWithInternalCompanion;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcases/enums/EnumWithInternalCompanion;
+	public static fun values ()[Lcases/enums/EnumWithInternalCompanion;
+}
+
 public final class cases/enums/JavaEnum : java/lang/Enum {
 	public static final field JA Lcases/enums/JavaEnum;
 	public static final field JB Lcases/enums/JavaEnum;


### PR DESCRIPTION
#245 fixed the way `const var`s from companion objects are handled. Unfortunately, the solution interferes with how any other static final fields are processed.

This PR postpones companion class resolution until it's known that a field corresponds to a property declared in a companion object.

Fixes #250