### PR TITLE
Avoid using project.name for ignored projects check

### DIFF
--- a/src/main/kotlin/BuildTaskBase.kt
+++ b/src/main/kotlin/BuildTaskBase.kt
@@ -48,9 +48,6 @@ public abstract class BuildTaskBase : WorkerAwareTaskBase() {
     @get:Input
     public val publicClasses: SetProperty<String> = stringSetProperty { publicClasses }
 
-    @get:Internal
-    internal val projectName = project.name
-
     internal fun fillCommonParams(params: BuildParametersBase) {
         params.ignoredPackages.set(ignoredPackages)
         params.nonPublicMarkers.set(nonPublicMarkers)

--- a/src/main/kotlin/KotlinApiCompareTask.kt
+++ b/src/main/kotlin/KotlinApiCompareTask.kt
@@ -8,7 +8,6 @@ package kotlinx.validation
 import com.github.difflib.DiffUtils
 import com.github.difflib.UnifiedDiffUtils
 import java.io.*
-import javax.inject.Inject
 import org.gradle.api.*
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.*
@@ -23,7 +22,7 @@ public open class KotlinApiCompareTask : DefaultTask() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     public val generatedApiFile: RegularFileProperty = project.objects.fileProperty()
 
-    private val projectName = project.name
+    private val projectPath = project.path
 
     private val rootDir = project.rootDir
 
@@ -51,10 +50,9 @@ public open class KotlinApiCompareTask : DefaultTask() {
         if (diff != null) diffSet.add(diff)
         if (diffSet.isNotEmpty()) {
             val diffText = diffSet.joinToString("\n\n")
-            val subject = projectName
             error(
-                "API check failed for project $subject.\n$diffText\n\n" +
-                        "You can run :$subject:apiDump task to overwrite API declarations"
+                "API check failed for project $projectPath.\n$diffText\n\n" +
+                        "You can run $projectPath:apiDump task to overwrite API declarations"
             )
         }
     }


### PR DESCRIPTION
- Closes #16.
- Closes #257.


> The project's name is not necessarily unique within a project hierarchy. You should use the getPath() method for a unique identifier for the project.

See https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#getName().