### PR TITLE
Updated warning about freezing development

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,13 @@
 
 # Support for this plugin has been discontinued
 
-> [!WARNING]
-> The development of a separate binary compatibility validator Gradle plugin has been discontinued, 
-> and all its functionality will be moved to Kotlin Gradle Plugin starting from the [`2.2.0` release](https://kotlinlang.org/docs/whatsnew22.html#binary-compatibility-validation-included-in-kotlin-gradle-plugin).
+> [!IMPORTANT]
+> This plugin is in maintenance mode.
 > 
-> As part of the migration, the code of the current plugin has been migrated to [the Kotlin repository](https://github.com/JetBrains/kotlin/tree/master/libraries/tools/abi-validation), 
-> as well as issues migrated to [the Kotlin project in YouTrack](https://youtrack.jetbrains.com/issues/KT?q=subsystems:%20%7BTools.%20BCV%7D,%20%7BTools.%20Gradle.%20BCV%7D).
+> Fixes for critical bugs and support for current versions of Kotlin continue to be delivered. 
 > 
-> This plugin is frozen from changes, no new features or minor bugfixes will be added to it.
-> 
-> The functionality of working with the ABI in Kotlin Gradle Plugin is in an experimental state now, 
-> so it is recommended to continue using this plugin in production projects until KGP API stabilization.
+> The implementation of new features has been stopped in favor of adding them to the [experimental binary compatibility validation in the Kotlin Gradle plugin](https://kotlinlang.org/docs/gradle-binary-compatibility-validation.html)
+
 
 # Binary compatibility validator
 


### PR DESCRIPTION
The previous wording sounded too threatening and gave the impression that the plugin would not be supported for new versions of Kotlin.